### PR TITLE
Add pedantic_mono: a lint tool

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,2 @@
+# https://pub.dev/packages/pedantic_mono
+include: package:pedantic_mono/analysis_options.yaml

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -289,6 +289,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.0"
+  pedantic_mono:
+    dependency: "direct dev"
+    description:
+      name: pedantic_mono
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.9.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dev_dependencies:
     sdk: flutter
   bloc_test: ^5.0.0
   mockito: ^4.1.1
+  pedantic_mono: any
 
 flutter:
 


### PR DESCRIPTION
Fix #38 

静的解析ツールのパッケージ追加しました。

`const` つけてね、的なのが出るようになってると思う!
![image](https://user-images.githubusercontent.com/7913793/84357581-db73d380-ac00-11ea-8e30-464d67bd535a.png)


参考
https://medium.com/flutter-jp/analysis-b8dbb19d3978