### PR TITLE
Build create new board screen

### DIFF
--- a/lib/bloc/new_board_sreen_bloc.dart
+++ b/lib/bloc/new_board_sreen_bloc.dart
@@ -18,7 +18,7 @@ class BoardNameChanged extends NewBoardScreenBlocEvent {
   List<Object> get props => [value];
 }
 
-abstract class IsPrivateChanged extends NewBoardScreenBlocEvent {}
+class IsPrivateChanged extends NewBoardScreenBlocEvent {}
 
 abstract class NewBoardScreenBlocState extends Equatable {
   NewBoardScreenBlocState({

--- a/lib/bloc/new_board_sreen_bloc.dart
+++ b/lib/bloc/new_board_sreen_bloc.dart
@@ -7,7 +7,7 @@ abstract class NewBoardScreenBlocEvent extends Equatable {
   List<Object> get props => [];
 }
 
-abstract class BoardNameChanged extends NewBoardScreenBlocEvent {
+class BoardNameChanged extends NewBoardScreenBlocEvent {
   BoardNameChanged({
     @required this.value,
   });
@@ -55,14 +55,14 @@ class NewBoardScreenBloc
   Stream<NewBoardScreenBlocState> mapEventToState(
       NewBoardScreenBlocEvent event) async* {
     if (event is BoardNameChanged) {
-      DefaultState(
+      yield DefaultState(
         boardName: event.value,
         isPrivate: state.isPrivate,
       );
     }
 
     if (event is IsPrivateChanged) {
-      DefaultState(
+      yield DefaultState(
         boardName: state.boardName,
         isPrivate: !state.isPrivate,
       );

--- a/lib/bloc/new_board_sreen_bloc.dart
+++ b/lib/bloc/new_board_sreen_bloc.dart
@@ -1,0 +1,71 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+abstract class NewBoardScreenBlocEvent extends Equatable {
+  @override
+  List<Object> get props => [];
+}
+
+abstract class BoardNameChanged extends NewBoardScreenBlocEvent {
+  BoardNameChanged({
+    @required this.value,
+  });
+
+  final String value;
+
+  @override
+  List<Object> get props => [value];
+}
+
+abstract class IsPrivateChanged extends NewBoardScreenBlocEvent {}
+
+abstract class NewBoardScreenBlocState extends Equatable {
+  NewBoardScreenBlocState({
+    @required this.boardName,
+    @required this.isPrivate,
+  });
+
+  final String boardName;
+  final bool isPrivate;
+
+  @override
+  List<Object> get props => [boardName, isPrivate];
+}
+
+class DefaultState extends NewBoardScreenBlocState {
+  DefaultState({
+    @required String boardName,
+    @required bool isPrivate,
+  }) : super(
+          boardName: boardName,
+          isPrivate: isPrivate,
+        );
+}
+
+class NewBoardScreenBloc
+    extends Bloc<NewBoardScreenBlocEvent, NewBoardScreenBlocState> {
+  @override
+  NewBoardScreenBlocState get initialState => DefaultState(
+        boardName: '',
+        isPrivate: false,
+      );
+
+  @override
+  Stream<NewBoardScreenBlocState> mapEventToState(
+      NewBoardScreenBlocEvent event) async* {
+    if (event is BoardNameChanged) {
+      DefaultState(
+        boardName: event.value,
+        isPrivate: state.isPrivate,
+      );
+    }
+
+    if (event is IsPrivateChanged) {
+      DefaultState(
+        boardName: state.boardName,
+        isPrivate: !state.isPrivate,
+      );
+    }
+  }
+}

--- a/lib/bloc/new_board_sreen_bloc.dart
+++ b/lib/bloc/new_board_sreen_bloc.dart
@@ -20,6 +20,8 @@ class BoardNameChanged extends NewBoardScreenBlocEvent {
 
 class IsPrivateChanged extends NewBoardScreenBlocEvent {}
 
+class CreateBoardRequested extends NewBoardScreenBlocEvent {}
+
 abstract class NewBoardScreenBlocState extends Equatable {
   NewBoardScreenBlocState({
     @required this.boardName,
@@ -66,6 +68,11 @@ class NewBoardScreenBloc
         boardName: state.boardName,
         isPrivate: !state.isPrivate,
       );
+    }
+
+    if (event is CreateBoardRequested) {
+      // TODO: 実際にBoardを作成する処理に差し替え
+      print('board name: ${state.boardName}, isPrivate: ${state.isPrivate}');
     }
   }
 }

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -20,21 +20,25 @@ class NewBoardScreen extends StatelessWidget {
         padding: EdgeInsets.all(8),
         child: Column(
           children: <Widget>[
-            TextField(
-              decoration: InputDecoration(
-                labelText: 'Board name',
-                hintText: 'Type something...',
-                border: OutlineInputBorder(),
-              ),
-              onChanged: (value) {
-                // TODO 変更を通知する
-              },
-            ),
+            _buildBoardNameTextField(context),
             SizedBox(height: 20),
             _buildPrivateBoardSwitch(context),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildBoardNameTextField(BuildContext context) {
+    return TextField(
+      decoration: InputDecoration(
+        labelText: 'Board name',
+        hintText: 'Type something...',
+        border: OutlineInputBorder(),
+      ),
+      onChanged: (value) {
+        // TODO 変更を通知する
+      },
     );
   }
 

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -30,14 +30,12 @@ class NewBoardScreen extends StatelessWidget {
               child: Text('Create'),
               onPressed: state.boardName.isEmpty
                   ? null
-                  : () {
-                      // TODO
-                    },
+                  : () => _onCreateButtonPressed(context),
             )
           ],
         ),
         body: Container(
-          padding: EdgeInsets.all(8),
+          padding: EdgeInsets.all(16),
           child: Column(
             children: <Widget>[
               _buildBoardNameTextField(context),
@@ -78,5 +76,10 @@ class NewBoardScreen extends StatelessWidget {
         ),
       ],
     );
+  }
+
+  void _onCreateButtonPressed(BuildContext context) {
+    final bloc = BlocProvider.of<NewBoardScreenBloc>(context);
+    bloc.add(CreateBoardRequested());
   }
 }

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -16,8 +16,22 @@ class NewBoardScreen extends StatelessWidget {
           ),
         ),
       ),
-      body: MockScreenCommon(
-        name: 'New board screen',
+      body: Container(
+        padding: EdgeInsets.all(8),
+        child: Column(
+          children: <Widget>[
+            TextField(
+              decoration: InputDecoration(
+                labelText: 'Board name',
+                hintText: 'Type something...',
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (value) {
+                // TODO 変更を通知する
+              },
+            )
+          ],
+        ),
       ),
     );
   }

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -65,14 +65,15 @@ class NewBoardScreen extends StatelessWidget {
   }
 
   Widget _buildPrivateBoardSwitch(BuildContext context) {
+    final bloc = BlocProvider.of<NewBoardScreenBloc>(context);
     return Row(
       children: <Widget>[
         Text('Private board'),
         Spacer(),
         Switch(
-          value: false, // TODO
+          value: bloc.state.isPrivate, // TODO
           onChanged: (value) {
-            // TODO
+            bloc.add(IsPrivateChanged());
           },
         ),
       ],

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -13,34 +13,38 @@ class NewBoardScreen extends StatelessWidget {
   }
 
   Widget _buildScreen(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          'Create a new board',
-        ),
-        leading: Container(
-          child: IconButton(
-            icon: Icon(Icons.close),
-            onPressed: () => Navigator.of(context).pop(),
+    return BlocBuilder<NewBoardScreenBloc, NewBoardScreenBlocState>(
+      builder: (context, state) => Scaffold(
+        appBar: AppBar(
+          title: Text(
+            'Create a new board',
           ),
-        ),
-        actions: <Widget>[
-          RaisedButton(
-            child: Text('Create'),
-            onPressed: () {
-              // TODO
-            },
-          )
-        ],
-      ),
-      body: Container(
-        padding: EdgeInsets.all(8),
-        child: Column(
-          children: <Widget>[
-            _buildBoardNameTextField(context),
-            SizedBox(height: 20),
-            _buildPrivateBoardSwitch(context),
+          leading: Container(
+            child: IconButton(
+              icon: Icon(Icons.close),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+          ),
+          actions: <Widget>[
+            RaisedButton(
+              child: Text('Create'),
+              onPressed: state.boardName.isEmpty
+                  ? null
+                  : () {
+                      // TODO
+                    },
+            )
           ],
+        ),
+        body: Container(
+          padding: EdgeInsets.all(8),
+          child: Column(
+            children: <Widget>[
+              _buildBoardNameTextField(context),
+              SizedBox(height: 20),
+              _buildPrivateBoardSwitch(context),
+            ],
+          ),
         ),
       ),
     );
@@ -54,7 +58,8 @@ class NewBoardScreen extends StatelessWidget {
         border: OutlineInputBorder(),
       ),
       onChanged: (value) {
-        // TODO 変更を通知する
+        BlocProvider.of<NewBoardScreenBloc>(context)
+            .add(BoardNameChanged(value: value));
       },
     );
   }

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -1,9 +1,18 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mobile/bloc/new_board_sreen_bloc.dart';
 import 'package:mobile/view/mock/mock_screen_common.dart';
 
 class NewBoardScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    return BlocProvider<NewBoardScreenBloc>(
+      create: (context) => NewBoardScreenBloc(),
+      child: _buildScreen(context),
+    );
+  }
+
+  Widget _buildScreen(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: Text(

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -69,7 +69,7 @@ class NewBoardScreen extends StatelessWidget {
         Text('Private board'),
         Spacer(),
         Switch(
-          value: bloc.state.isPrivate, // TODO
+          value: bloc.state.isPrivate,
           onChanged: (value) {
             bloc.add(IsPrivateChanged());
           },

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -29,10 +29,27 @@ class NewBoardScreen extends StatelessWidget {
               onChanged: (value) {
                 // TODO 変更を通知する
               },
-            )
+            ),
+            SizedBox(height: 20),
+            _buildPrivateBoardSwitch(context),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildPrivateBoardSwitch(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        Text('Private board'),
+        Spacer(),
+        Switch(
+          value: false, // TODO
+          onChanged: (value) {
+            // TODO
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -15,6 +15,14 @@ class NewBoardScreen extends StatelessWidget {
             onPressed: () => Navigator.of(context).pop(),
           ),
         ),
+        actions: <Widget>[
+          RaisedButton(
+            child: Text('Create'),
+            onPressed: () {
+              // TODO
+            },
+          )
+        ],
       ),
       body: Container(
         padding: EdgeInsets.all(8),


### PR DESCRIPTION
Fix #55 

board nameが空のとき、createボタンが押せないようになるのがポイントです。

現時点で、createボタンを押しても何も起きない&デザインはダサいけど、このPRではここまでとしてます。


| 1 | 2 |
| - | - |
| ![image](https://user-images.githubusercontent.com/7913793/84457441-9ea9ea00-ac9d-11ea-93a3-a9884d49d27c.png) | ![image](https://user-images.githubusercontent.com/7913793/84457448-a49fcb00-ac9d-11ea-9227-a121d37baf1c.png) |




