### PR TITLE
ピンの作成の遷移周りの実装

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,23 +18,42 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Pinterest',
-      home: RootScreen(),
-      routes: {
-        // Pin
-        '/pin/detail': (context) => PinDetailScreen(),
-        '/pin/edit': (context) => PinEditScreen(),
+      onGenerateRoute: (RouteSettings settings) {
+        switch (settings.name) {
+          case '/':
+            return _pageRoute(RootScreen());
+          // Pin
+          case '/pin/detail':
+            return _pageRoute(PinDetailScreen());
+          case '/pin/edit':
+            return _pageRoute(PinEditScreen());
+          // Board
+          case '/board/detail':
+            return _pageRoute(BoardDetailScreen());
+          case '/board/edit':
+            return _pageRoute(BoardEditScreen());
+          // Create new pin/board
+          case '/new':
+            return _pageRoute(CreateNewScreen());
+          case '/new/board':
+            return _pageRoute(NewBoardScreen());
+          case '/new/pin/select-photo':
+            return _pageRoute(PinSelectPhotoScreen(), fullScreenDialog: true);
+          case '/new/pin/edit':
+            return _pageRoute(PinEditScreen());
+          case '/new/pin/select-board':
+            return _pageRoute(SelectBoardScreen());
+        }
 
-        // Board
-        '/board/edit': (context) => BoardEditScreen(),
-        '/board/detail': (context) => BoardDetailScreen(),
-
-        // Create new pin/board
-        '/new': (context) => CreateNewScreen(),
-        '/new/board': (context) => NewBoardScreen(),
-        '/new/pin/select-photo': (context) => PinSelectPhotoScreen(),
-        '/new/pin/edit': (context) => PinEditScreen(),
-        '/new/pin/select-board': (context) => SelectBoardScreen(),
+        return null;
       },
+    );
+  }
+
+  MaterialPageRoute _pageRoute(Widget widget, {bool fullScreenDialog = false}) {
+    return MaterialPageRoute(
+      builder: (context) => widget,
+      fullscreenDialog: fullScreenDialog,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,7 +21,7 @@ class MyApp extends StatelessWidget {
       onGenerateRoute: (RouteSettings settings) {
         switch (settings.name) {
           case '/':
-            return _pageRoute(RootScreen());
+            return _pageRoute(RootScreen(), name: '/');
           // Pin
           case '/pin/detail':
             return _pageRoute(PinDetailScreen());
@@ -38,7 +38,10 @@ class MyApp extends StatelessWidget {
           case '/new/board':
             return _pageRoute(NewBoardScreen());
           case '/new/pin/select-photo':
-            return _pageRoute(PinSelectPhotoScreen(), fullScreenDialog: true);
+            return _pageRoute(
+              PinSelectPhotoScreen(),
+              fullScreenDialog: true,
+            );
           case '/new/pin/edit':
             return _pageRoute(PinEditScreen());
           case '/new/pin/select-board':
@@ -50,8 +53,15 @@ class MyApp extends StatelessWidget {
     );
   }
 
-  MaterialPageRoute _pageRoute(Widget widget, {bool fullScreenDialog = false}) {
-    return MaterialPageRoute(
+  MaterialPageRoute _pageRoute(
+    Widget widget, {
+    bool fullScreenDialog = false,
+    String name,
+  }) {
+    return MaterialPageRoute<dynamic>(
+      settings: RouteSettings(
+        name: name,
+      ),
       builder: (context) => widget,
       fullscreenDialog: fullScreenDialog,
     );

--- a/lib/view/create_new_screen.dart
+++ b/lib/view/create_new_screen.dart
@@ -22,7 +22,7 @@ class CreateNewScreen extends StatelessWidget {
               RaisedButton(
                 child: Text('Pin'),
                 onPressed: () {
-                  Navigator.of(context).pushNamed('/new/pin/select-photo');
+                  Navigator.of(context).pushReplacementNamed('/new/pin/select-photo');
                 },
               ),
             ],

--- a/lib/view/pin_edit_screen.dart
+++ b/lib/view/pin_edit_screen.dart
@@ -4,9 +4,17 @@ import 'package:mobile/view/mock/mock_screen_common.dart';
 class PinEditScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: MockScreenCommon(
-        name: 'Pin edit screen',
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Create pin'),
+      ),
+      body: Container(
+        child: RaisedButton(
+          child: Text('Next'),
+          onPressed: () {
+            Navigator.pushNamed(context, '/new/pin/select-board');
+          },
+        ),
       ),
     );
   }

--- a/lib/view/pin_select_photo_screen.dart
+++ b/lib/view/pin_select_photo_screen.dart
@@ -9,8 +9,11 @@ class PinSelectPhotoScreen extends StatelessWidget {
         title: Text('Select photo'),
       ),
       body: Container(
-        child: MockScreenCommon(
-          name: 'Pin select photo screen',
+        child: RaisedButton(
+          child: Text('Next'),
+          onPressed: () {
+            Navigator.pushNamed(context, '/new/pin/edit');
+          },
         ),
       ),
     );

--- a/lib/view/pin_select_photo_screen.dart
+++ b/lib/view/pin_select_photo_screen.dart
@@ -4,9 +4,14 @@ import 'package:mobile/view/mock/mock_screen_common.dart';
 class PinSelectPhotoScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: MockScreenCommon(
-        name: 'Pin select photo screen',
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Select photo'),
+      ),
+      body: Container(
+        child: MockScreenCommon(
+          name: 'Pin select photo screen',
+        ),
       ),
     );
   }

--- a/lib/view/select_board_screen.dart
+++ b/lib/view/select_board_screen.dart
@@ -4,9 +4,17 @@ import 'package:mobile/view/mock/mock_screen_common.dart';
 class SelectBoardScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      child: MockScreenCommon(
-        name: 'select board screen',
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Select board'),
+      ),
+      body: Container(
+        child: RaisedButton(
+          child: Text('Select board'),
+          onPressed: () {
+            Navigator.of(context).popUntil(ModalRoute.withName('/'));
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
Fix #59 

![navigations](https://user-images.githubusercontent.com/7913793/84467271-99a56480-acb6-11ea-8bb1-d38a658550b5.gif)


ピンの作成の遷移まわりの実装が不安だったので、調査しつつ遷移だけ行えるように実装しました。
ポイントは `pushReplacementNamed` で一方通行の遷移ができることと、`popUntil` で好きな画面まで一気に戻っているところです。

`onGenerateRoute` を使うと、routeのnameがnullになってしまうっぽいので、popUntilをしたいrouteには明示的にnameを与えています。

