### PR TITLE
共通ボタンwidgetの実装

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,9 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Pinterest',
       home: RootScreen(),
+      theme: ThemeData(
+        buttonColor: Colors.red,
+      ),
       routes: {
         // Pin
         '/pin/detail': (context) => PinDetailScreen(),

--- a/lib/view/components/common/button_common.dart
+++ b/lib/view/components/common/button_common.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+enum PinterestButtonVariant {
+  primary,
+  secondary,
+}
+
+class PinterestButton extends StatelessWidget {
+  PinterestButton.primary({
+    @required this.text,
+    @required this.onPressed,
+  }) : variant = PinterestButtonVariant.primary;
+
+  PinterestButton.secondary({
+    @required this.text,
+    @required this.onPressed,
+  }) : variant = PinterestButtonVariant.secondary;
+
+  final String text;
+  final VoidCallback onPressed;
+  final PinterestButtonVariant variant;
+
+  @override
+  Widget build(BuildContext context) {
+    return RaisedButton(
+      child: Text(
+        text,
+        style: TextStyle(
+          color: variant == PinterestButtonVariant.primary
+              ? Colors.white
+              : Colors.black,
+        ),
+      ),
+      onPressed: onPressed,
+      color: variant == PinterestButtonVariant.primary
+          ? Theme.of(context).buttonColor
+          : Colors.grey[300],
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(9999),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Fix #63 

`PinterestButton.primary()`, `PinterestButton.secondary()` でいい感じのボタンを作れます。

![image](https://user-images.githubusercontent.com/7913793/84479817-830b0780-acce-11ea-86b3-3cffc79eaebf.png)

---

これからwidgetの見た目を確認したいことが増えてくると思うので、
そのためのデバッグ用screenを別途用意しようと思います→ #65
