### PR TITLE
Text系共通widgetの実装

### DIFF
--- a/lib/view/components/common/typography_common.dart
+++ b/lib/view/components/common/typography_common.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 
-class Typography extends Text {
-  Typography.body1(String data) : super(data, style: TextStyle(fontSize: 20));
+class PinterestTypography extends Text {
+  PinterestTypography.body1(String data)
+      : super(data, style: TextStyle(fontSize: 18));
 
-  Typography.body2(String data) : super(data, style: TextStyle(fontSize: 16));
+  PinterestTypography.body2(String data)
+      : super(data, style: TextStyle(fontSize: 14));
 
-  Typography.header(String data) : super(data, style: TextStyle(fontSize: 24));
+  PinterestTypography.header(String data)
+      : super(data, style: TextStyle(fontSize: 32));
 }

--- a/lib/view/components/common/typography_common.dart
+++ b/lib/view/components/common/typography_common.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+class Typography extends Text {
+  Typography.body1(String data) : super(data, style: TextStyle(fontSize: 20));
+
+  Typography.body2(String data) : super(data, style: TextStyle(fontSize: 16));
+
+  Typography.header(String data) : super(data, style: TextStyle(fontSize: 24));
+}


### PR DESCRIPTION
Fix #76 

画像の通り、3種類のfontsizeのTextウィジェットを追加しました。

* body1
* body2
* header

`PinterestTypography.body(...)` という感じで使えます。

![image](https://user-images.githubusercontent.com/7913793/84622438-f5baf380-af17-11ea-8a25-5e7ce8eceff3.png)
