### PR TITLE
Playground screenの実装

### DIFF
--- a/lib/view/playground_screen.dart
+++ b/lib/view/playground_screen.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:mobile/view/components/common/button_common.dart';
+import 'package:mobile/view/components/common/textfield_common.dart';
+import 'package:mobile/view/components/common/typography_common.dart';
+
+class PlaygroundScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                PinterestButton.primary(text: 'Primary', onPressed: () {}),
+                SizedBox(width: 20),
+                PinterestButton.secondary(text: 'Primary', onPressed: () {}),
+              ],
+            ),
+            PinterestTextField(
+              label: 'Title',
+              hintText: 'hint etxt',
+            ),
+            PinterestTextField(
+              label: 'Name',
+              hintText: 'Type your name',
+            ),
+            PinterestTypography.body1('body1'),
+            PinterestTypography.body2('body2'),
+            PinterestTypography.header('header'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/playground_screen.dart
+++ b/lib/view/playground_screen.dart
@@ -11,36 +11,9 @@ class PlaygroundScreen extends StatelessWidget {
         padding: const EdgeInsets.all(16),
         child: Container(
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              _Section(
-                'Buttons',
-                children: <Widget>[
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      PinterestButton.primary(
-                          text: 'Primary', onPressed: () {}),
-                      SizedBox(width: 20),
-                      PinterestButton.secondary(
-                          text: 'Primary', onPressed: () {}),
-                    ],
-                  ),
-                ],
-              ),
-              _Section(
-                'TextField',
-                children: <Widget>[
-                  PinterestTextField(
-                    label: 'Title',
-                    hintText: 'hint etxt',
-                  ),
-                  PinterestTextField(
-                    label: 'Name',
-                    hintText: 'Type your name',
-                  ),
-                ],
-              ),
+              _buildButtonsSection(),
+              _buildTextFieldSection(),
               _buildTypographySection(),
             ],
           ),
@@ -49,17 +22,49 @@ class PlaygroundScreen extends StatelessWidget {
     );
   }
 
+  Widget _buildButtonsSection() {
+    return _Section(
+      'Buttons',
+      children: <Widget>[
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            PinterestButton.primary(text: 'Primary', onPressed: () {}),
+            const SizedBox(width: 20),
+            PinterestButton.secondary(text: 'Primary', onPressed: () {}),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTextFieldSection() {
+    return _Section(
+      'TextField',
+      children: <Widget>[
+        PinterestTextField(
+          label: 'Title',
+          hintText: 'hint etxt',
+        ),
+        PinterestTextField(
+          label: 'Name',
+          hintText: 'Type your name',
+        ),
+      ],
+    );
+  }
+
   Widget _buildTypographySection() {
-    final sampleText =
+    const sampleText =
         '''Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.''';
 
     return _Section(
       'Typography',
       children: <Widget>[
         PinterestTypography.body1('body1: $sampleText'),
-        SizedBox(height: 12),
+        const SizedBox(height: 12),
         PinterestTypography.body2('body2: $sampleText'),
-        SizedBox(height: 12),
+        const SizedBox(height: 12),
         PinterestTypography.header('header: Lorem Ipsum'),
       ],
     );
@@ -67,7 +72,7 @@ class PlaygroundScreen extends StatelessWidget {
 }
 
 class _Section extends StatelessWidget {
-  _Section(
+  const _Section(
     this.header, {
     this.children,
   });
@@ -78,7 +83,7 @@ class _Section extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.only(bottom: 24),
+      margin: const EdgeInsets.only(bottom: 32),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[

--- a/lib/view/playground_screen.dart
+++ b/lib/view/playground_screen.dart
@@ -7,31 +7,88 @@ class PlaygroundScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      child: Container(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                PinterestButton.primary(text: 'Primary', onPressed: () {}),
-                SizedBox(width: 20),
-                PinterestButton.secondary(text: 'Primary', onPressed: () {}),
-              ],
-            ),
-            PinterestTextField(
-              label: 'Title',
-              hintText: 'hint etxt',
-            ),
-            PinterestTextField(
-              label: 'Name',
-              hintText: 'Type your name',
-            ),
-            PinterestTypography.body1('body1'),
-            PinterestTypography.body2('body2'),
-            PinterestTypography.header('header'),
-          ],
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Container(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              _Section(
+                'Buttons',
+                children: <Widget>[
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      PinterestButton.primary(
+                          text: 'Primary', onPressed: () {}),
+                      SizedBox(width: 20),
+                      PinterestButton.secondary(
+                          text: 'Primary', onPressed: () {}),
+                    ],
+                  ),
+                ],
+              ),
+              _Section(
+                'TextField',
+                children: <Widget>[
+                  PinterestTextField(
+                    label: 'Title',
+                    hintText: 'hint etxt',
+                  ),
+                  PinterestTextField(
+                    label: 'Name',
+                    hintText: 'Type your name',
+                  ),
+                ],
+              ),
+              _buildTypographySection(),
+            ],
+          ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildTypographySection() {
+    final sampleText =
+        '''Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.''';
+
+    return _Section(
+      'Typography',
+      children: <Widget>[
+        PinterestTypography.body1('body1: $sampleText'),
+        SizedBox(height: 12),
+        PinterestTypography.body2('body2: $sampleText'),
+        SizedBox(height: 12),
+        PinterestTypography.header('header: Lorem Ipsum'),
+      ],
+    );
+  }
+}
+
+class _Section extends StatelessWidget {
+  _Section(
+    this.header, {
+    this.children,
+  });
+
+  final String header;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          PinterestTypography.header(header),
+          const SizedBox(height: 18),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: children,
+          ),
+        ],
       ),
     );
   }

--- a/lib/view/root_screen.dart
+++ b/lib/view/root_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mobile/view/account_screen.dart';
 import 'package:mobile/view/home_screen.dart';
+import 'package:mobile/view/playground_screen.dart';
 
 class RootScreenDestination {
   final int index;
@@ -13,7 +14,8 @@ class RootScreenDestination {
 
 final List<RootScreenDestination> rootScreenDestinations = [
   RootScreenDestination(0, 'Home', HomeScreen(), Icons.home),
-  RootScreenDestination(1, 'Account', AccountScreen(), Icons.account_circle),
+  RootScreenDestination(1, 'Playground', PlaygroundScreen(), Icons.airplay),
+  RootScreenDestination(2, 'Account', AccountScreen(), Icons.account_circle),
 ];
 
 class RootScreen extends StatefulWidget {


### PR DESCRIPTION
Fix #65 

いい感じに共通widgetの表示を確認できるスクリーンを追加しました。
のちのち他にも表示を確認したいwidgetが出てきたらこのスクリーンを使うのがいいと思います。

(リリース前にはこのスクリーンが入らないようにします。)

![image](https://user-images.githubusercontent.com/7913793/84716974-8bee2880-afaf-11ea-9254-e809af19b87b.png)
