### PR TITLE
ロガー入れた

### DIFF
--- a/lib/bloc/home_screen_bloc.dart
+++ b/lib/bloc/home_screen_bloc.dart
@@ -2,9 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
-import 'package:http/http.dart';
-import 'package:mobile/api/api_client.dart';
-import 'package:mobile/api/pins_api.dart';
+import 'package:logger/logger.dart';
 import 'package:mobile/model/models.dart';
 import 'package:mobile/repository/repositories.dart';
 
@@ -78,7 +76,7 @@ class HomeScreenBloc extends Bloc<HomeScreenEvent, HomeScreenState> {
         final _pins = List<Pin>.from(state.pins)..addAll(_additionalPins);
         yield DefaultState(page: state.page + 1, pins: _pins);
       } catch (e) {
-        print(e);
+        Logger().e(e);
         yield DefaultState(page: state.page, pins: state.pins);
       }
     }

--- a/lib/bloc/new_board_sreen_bloc.dart
+++ b/lib/bloc/new_board_sreen_bloc.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logger/logger.dart';
 
 abstract class NewBoardScreenBlocEvent extends Equatable {
   @override
@@ -72,7 +73,8 @@ class NewBoardScreenBloc
 
     if (event is CreateBoardRequested) {
       // TODO: 実際にBoardを作成する処理に差し替え
-      print('board name: ${state.boardName}, isPrivate: ${state.isPrivate}');
+      Logger()
+          .d('board name: ${state.boardName}, isPrivate: ${state.isPrivate}');
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:logger/logger.dart';
 import 'package:mobile/view/board_detail_screen.dart';
 import 'package:mobile/view/board_edit_screen.dart';
 import 'package:mobile/view/create_new_screen.dart';
@@ -10,6 +11,7 @@ import 'package:mobile/view/root_screen.dart';
 import 'package:mobile/view/select_board_screen.dart';
 
 void main() {
+  Logger.level = Level.verbose;
   runApp(MyApp());
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -310,6 +310,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.3.0"
+  logger:
+    dependency: "direct main"
+    description:
+      name: logger
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.1"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   dio: ^3.0.9
   json_annotation: ^3.0.1
   flutter_staggered_grid_view: ^0.3.0
+  logger: ^0.9.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fix #79 

loggerのドキュメント
https://pub.dev/packages/logger

`logger.d("Debug log");` のようにすると下のようなログを表示できます。
`print()`を使うよりロガーを使うのがいいかなと思い入れてみました。

![image](https://user-images.githubusercontent.com/7913793/84717690-8bef2800-afb1-11ea-8f9f-297b206fe1ce.png)
