### PR TITLE
Feature/31 implement pin select photo screen

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,8 +1,12 @@
 PODS:
   - Flutter (1.0.0)
+  - flutter_plugin_android_lifecycle (0.0.1):
+    - Flutter
   - FMDB (2.7.5):
     - FMDB/standard (= 2.7.5)
   - FMDB/standard (2.7.5)
+  - image_picker (0.0.1):
+    - Flutter
   - path_provider (0.0.1):
     - Flutter
   - path_provider_linux (0.0.1):
@@ -21,6 +25,8 @@ PODS:
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - flutter_plugin_android_lifecycle (from `.symlinks/plugins/flutter_plugin_android_lifecycle/ios`)
+  - image_picker (from `.symlinks/plugins/image_picker/ios`)
   - path_provider (from `.symlinks/plugins/path_provider/ios`)
   - path_provider_linux (from `.symlinks/plugins/path_provider_linux/ios`)
   - path_provider_macos (from `.symlinks/plugins/path_provider_macos/ios`)
@@ -36,6 +42,10 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  flutter_plugin_android_lifecycle:
+    :path: ".symlinks/plugins/flutter_plugin_android_lifecycle/ios"
+  image_picker:
+    :path: ".symlinks/plugins/image_picker/ios"
   path_provider:
     :path: ".symlinks/plugins/path_provider/ios"
   path_provider_linux:
@@ -53,7 +63,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  flutter_plugin_android_lifecycle: dc0b544e129eebb77a6bfb1239d4d1c673a60a35
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
+  image_picker: 66aa71bc96850a90590a35d4c4a2907b0d823109
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
   path_provider_linux: 4d630dc393e1f20364f3e3b4a2ff41d9674a84e4
   path_provider_macos: f760a3c5b04357c380e2fddb6f9db6f3015897e0

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -243,6 +243,8 @@
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/FMDB/FMDB.framework",
 				"${PODS_ROOT}/../Flutter/Flutter.framework",
+				"${BUILT_PRODUCTS_DIR}/flutter_plugin_android_lifecycle/flutter_plugin_android_lifecycle.framework",
+				"${BUILT_PRODUCTS_DIR}/image_picker/image_picker.framework",
 				"${BUILT_PRODUCTS_DIR}/path_provider/path_provider.framework",
 				"${BUILT_PRODUCTS_DIR}/shared_preferences/shared_preferences.framework",
 				"${BUILT_PRODUCTS_DIR}/sqflite/sqflite.framework",
@@ -251,6 +253,8 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FMDB.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_plugin_android_lifecycle.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/image_picker.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/sqflite.framework",

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -44,5 +44,12 @@
 	<key>UIStatusBarHidden</key>
 	<true/>
 
+	<!-- image_picker library https://pub.dev/packages/image_picker -->
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>I WANT TO USE YOUR PHOTOS!!!!!</string>
+	<key>NSCameraUsageDescription</key>
+	<string>I WANT TO SEE YOU!!!!!</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>I WANT TO LISTEN YOUR VOICE!!!!!</string>
 </dict>
 </plist>

--- a/lib/view/create_new_screen.dart
+++ b/lib/view/create_new_screen.dart
@@ -1,12 +1,18 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:mobile/routes.dart';
+import 'package:mobile/view/pin_edit_screen.dart';
 
 class CreateNewScreen extends StatelessWidget {
+  final ImagePicker picker = ImagePicker();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Create'),
+        title: const Text('Create'),
       ),
       body: Container(
         child: Center(
@@ -14,23 +20,29 @@ class CreateNewScreen extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
               RaisedButton(
-                child: Text('Board'),
+                child: const Text('Board'),
                 onPressed: () {
                   Navigator.of(context).pushNamed(Routes.createNewBoard);
                 },
               ),
-              SizedBox(width: 20),
+              const SizedBox(width: 20),
               RaisedButton(
-                child: Text('Pin'),
-                onPressed: () {
-                  Navigator.of(context)
-                      .pushReplacementNamed(Routes.createNewPinSelectPhoto);
-                },
+                child: const Text('Pin'),
+                onPressed: () => _onPinPressed(context),
               ),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  Future _onPinPressed(BuildContext context) async {
+    final pickedFile = await picker.getImage(source: ImageSource.gallery);
+    final file = File(pickedFile.path);
+    Navigator.of(context).pushReplacementNamed(
+      Routes.createNewPinEdit,
+      arguments: PinEditScreenArguments(file: file),
     );
   }
 }

--- a/lib/view/pin_edit_screen.dart
+++ b/lib/view/pin_edit_screen.dart
@@ -1,8 +1,20 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:mobile/routes.dart';
-import 'package:mobile/view/mock/mock_screen_common.dart';
+
+class PinEditScreenArguments {
+  PinEditScreenArguments({this.file});
+
+  File file;
+}
 
 class PinEditScreen extends StatelessWidget {
+  const PinEditScreen({this.args});
+
+  final PinEditScreenArguments args;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -10,11 +22,16 @@ class PinEditScreen extends StatelessWidget {
         title: Text('Create pin'),
       ),
       body: Container(
-        child: RaisedButton(
-          child: Text('Next'),
-          onPressed: () {
-            Navigator.pushNamed(context, Routes.createNewPinSelectPhoto);
-          },
+        child: Column(
+          children: [
+            Image.file(args.file),
+            RaisedButton(
+              child: Text('Next'),
+              onPressed: () {
+                Navigator.pushNamed(context, Routes.createNewPinSelectPhoto);
+              },
+            )
+          ],
         ),
       ),
     );

--- a/lib/view/pinterest_application.dart
+++ b/lib/view/pinterest_application.dart
@@ -102,16 +102,17 @@ class PinterestApplication extends StatelessWidget {
               return _pageRoute(BoardEditScreen());
             // Create new pin/board
             case Routes.createNew:
-              return _pageRoute(CreateNewScreen());
+              return _pageRoute(
+                CreateNewScreen(),
+                fullScreenDialog: true,
+              );
             case Routes.createNewBoard:
               return _pageRoute(NewBoardScreen());
             case Routes.createNewPinSelectPhoto:
-              return _pageRoute(
-                PinSelectPhotoScreen(),
-                fullScreenDialog: true,
-              );
+              return _pageRoute(PinSelectPhotoScreen());
             case Routes.createNewPinEdit:
-              return _pageRoute(PinEditScreen());
+              final args = settings.arguments as PinEditScreenArguments;
+              return _pageRoute(PinEditScreen(args: args));
             case Routes.createNewPinSelectBoard:
               return _pageRoute(SelectBoardScreen());
           }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -211,6 +211,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   file:
     dependency: transitive
     description:
@@ -256,6 +263,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.9"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.8"
   flutter_staggered_grid_view:
     dependency: "direct main"
     description:
@@ -322,6 +336,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.12"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.7+2"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   intl:
     dependency: transitive
     description:
@@ -454,7 +482,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.7.0"
   path_provider:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   logger: ^0.9.1
   shared_preferences: ^0.5.7+3
   cached_network_image: ^2.2.0
+  image_picker: ^0.6.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
fix #31 

Done
- create new screen にimage pickerの導入
  - これによってpin select photo screenは不使用になる（ファイルは未削除） 
- create new screen を full screen dialogに変更（上記スクリーンが未使用になったこと、またUIの意味的にも、新規作成時にmodalになるのが望ましいと判断）
- pin edit screenに引数用のクラスを追加
- pin edit screenに確認用のimage widgetを追加（そのほかは未実装）
- iOSように設定ファイルの更新