### PR TITLE
ボードの作成の仕上げ

### DIFF
--- a/lib/bloc/new_board_sreen_bloc.dart
+++ b/lib/bloc/new_board_sreen_bloc.dart
@@ -72,7 +72,7 @@ class BoardCreateErrorState extends DefaultState {
 class NewBoardScreenBloc
     extends Bloc<NewBoardScreenBlocEvent, NewBoardScreenBlocState> {
   NewBoardScreenBloc({
-    this.boardRepo,
+   @required this.boardRepo,
   });
 
   final BoardsRepository boardRepo;

--- a/lib/bloc/new_board_sreen_bloc.dart
+++ b/lib/bloc/new_board_sreen_bloc.dart
@@ -49,6 +49,13 @@ class DefaultState extends NewBoardScreenBlocState {
   }) : super(boardName: boardName, isPrivate: isPrivate);
 }
 
+class BoardCreatingState extends NewBoardScreenBlocState {
+  BoardCreatingState({
+    @required String boardName,
+    @required bool isPrivate,
+  }) : super(boardName: boardName, isPrivate: isPrivate);
+}
+
 class BoardCreateSuccessState extends DefaultState {
   BoardCreateSuccessState({
     @required String boardName,
@@ -72,7 +79,7 @@ class BoardCreateErrorState extends DefaultState {
 class NewBoardScreenBloc
     extends Bloc<NewBoardScreenBlocEvent, NewBoardScreenBlocState> {
   NewBoardScreenBloc({
-   @required this.boardRepo,
+    @required this.boardRepo,
   });
 
   final BoardsRepository boardRepo;
@@ -101,6 +108,11 @@ class NewBoardScreenBloc
     }
 
     if (event is CreateBoardRequested) {
+      yield BoardCreatingState(
+        boardName: state.boardName,
+        isPrivate: state.isPrivate,
+      );
+
       final newBoard = NewBoard(
         name: state.boardName,
         isPrivate: state.isPrivate,

--- a/lib/bloc/new_board_sreen_bloc.dart
+++ b/lib/bloc/new_board_sreen_bloc.dart
@@ -2,7 +2,8 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:mobile/view/components/notification.dart';
+import 'package:mobile/model/board_model.dart';
+import 'package:mobile/repository/boards_repository.dart';
 import 'package:logger/logger.dart';
 
 abstract class NewBoardScreenBlocEvent extends Equatable {
@@ -27,29 +28,55 @@ class CreateBoardRequested extends NewBoardScreenBlocEvent {}
 
 abstract class NewBoardScreenBlocState extends Equatable {
   NewBoardScreenBlocState({
-    @required this.boardName,
-    @required this.isPrivate,
+    this.boardName,
+    this.isPrivate,
   });
 
   final String boardName;
   final bool isPrivate;
 
   @override
-  List<Object> get props => [boardName, isPrivate];
+  List<Object> get props => [
+        boardName,
+        isPrivate,
+      ];
 }
 
 class DefaultState extends NewBoardScreenBlocState {
   DefaultState({
     @required String boardName,
     @required bool isPrivate,
-  }) : super(
-          boardName: boardName,
-          isPrivate: isPrivate,
-        );
+  }) : super(boardName: boardName, isPrivate: isPrivate);
+}
+
+class BoardCreateSuccessState extends DefaultState {
+  BoardCreateSuccessState({
+    @required String boardName,
+    @required bool isPrivate,
+    @required this.createdBoard,
+  }) : super(boardName: boardName, isPrivate: isPrivate);
+
+  final Board createdBoard;
+}
+
+class BoardCreateErrorState extends DefaultState {
+  BoardCreateErrorState({
+    @required String boardName,
+    @required bool isPrivate,
+    @required this.errorMessage,
+  }) : super(boardName: boardName, isPrivate: isPrivate);
+
+  final String errorMessage;
 }
 
 class NewBoardScreenBloc
     extends Bloc<NewBoardScreenBlocEvent, NewBoardScreenBlocState> {
+  NewBoardScreenBloc({
+    this.boardRepo,
+  });
+
+  final BoardsRepository boardRepo;
+
   @override
   NewBoardScreenBlocState get initialState => DefaultState(
         boardName: '',
@@ -74,13 +101,27 @@ class NewBoardScreenBloc
     }
 
     if (event is CreateBoardRequested) {
-      // TODO: 実際にBoardを作成する処理に差し替え
-      PinterestNotification.show(
-        title: 'boardName: ${state.boardName}',
-        subtitle: 'isPrivate: ${state.isPrivate}',
+      final newBoard = NewBoard(
+        name: state.boardName,
+        isPrivate: state.isPrivate,
       );
-      Logger()
-          .d('board name: ${state.boardName}, isPrivate: ${state.isPrivate}');
+
+      Logger().d('board: $newBoard');
+
+      try {
+        final createdBoard = await boardRepo.createBoard(newBoard);
+        yield BoardCreateSuccessState(
+          boardName: state.boardName,
+          isPrivate: state.isPrivate,
+          createdBoard: createdBoard,
+        );
+      } catch (e) {
+        yield BoardCreateErrorState(
+          boardName: state.boardName,
+          isPrivate: state.isPrivate,
+          errorMessage: e.toString(),
+        );
+      }
     }
   }
 }

--- a/lib/repository/boards_repository.dart
+++ b/lib/repository/boards_repository.dart
@@ -2,7 +2,9 @@ import 'package:mobile/api/boards_api.dart';
 import 'package:mobile/model/models.dart';
 
 abstract class BoardsRepository {
-  Future<List<Pin>> getBoardPins({int id, int page}) async {}
+  Future<List<Pin>> getBoardPins({int id, int page});
+
+  Future<Board> createBoard(NewBoard board);
 }
 
 class DefaultBoardsRepository {
@@ -18,6 +20,8 @@ class DefaultBoardsRepository {
   Future<List<Pin>> getBoardPins({int id, int page}) async {
     return _api.boardPins(id: id, page: page);
   }
+
+  Future<Board> createBoard(NewBoard board) => _api.newBoard(board: board);
 }
 
 class MockBoardsRepository extends BoardsRepository {
@@ -33,5 +37,11 @@ class MockBoardsRepository extends BoardsRepository {
   Future<List<Pin>> getBoardPins({int id, int page}) async {
     final pins = List.filled(10, 1).map((_) => Pin.fromMock()).toList();
     return Future.value(pins);
+  }
+
+  @override
+  Future<Board> createBoard(NewBoard board) {
+    // TODO: implement createBoard
+    throw UnimplementedError();
   }
 }

--- a/lib/repository/boards_repository.dart
+++ b/lib/repository/boards_repository.dart
@@ -40,8 +40,12 @@ class MockBoardsRepository extends BoardsRepository {
   }
 
   @override
-  Future<Board> createBoard(NewBoard board) {
-    // TODO: implement createBoard
-    throw UnimplementedError();
+  Future<Board> createBoard(NewBoard board) async {
+    await Future<void>.delayed(const Duration(seconds: 1));
+    return Board(
+      name: board.name,
+      description: board.description,
+      isPrivate: board.isPrivate,
+    );
   }
 }

--- a/lib/view/components/notification.dart
+++ b/lib/view/components/notification.dart
@@ -16,6 +16,19 @@ class PinterestNotification {
     );
   }
 
+  // TODO: エラーの通知なので通知の色を
+  // エラーっぽい色にする
+  static void showError({
+    String title = 'Notification title',
+    String subtitle = '',
+    Duration duration = const Duration(seconds: 4),
+  }) =>
+      PinterestNotification.show(
+        title: title,
+        subtitle: subtitle,
+        duration: duration,
+      );
+
   static void showNotImplemented() {
     show(
       title: 'まだ実装してないねん。',

--- a/lib/view/create_new_screen.dart
+++ b/lib/view/create_new_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:mobile/model/board_model.dart';
 import 'package:mobile/routes.dart';
+import 'package:mobile/view/components/notification.dart';
 
 class CreateNewScreen extends StatelessWidget {
   @override
@@ -15,8 +17,16 @@ class CreateNewScreen extends StatelessWidget {
             children: <Widget>[
               RaisedButton(
                 child: Text('Board'),
-                onPressed: () {
-                  Navigator.of(context).pushNamed(Routes.createNewBoard);
+                onPressed: () async {
+                  final result = await Navigator.of(context)
+                      .pushReplacementNamed(Routes.createNewBoard);
+
+                  if (result is Board) {
+                    PinterestNotification.show(
+                      title: 'New board created',
+                      subtitle: result.name,
+                    );
+                  }
                 },
               ),
               SizedBox(width: 20),

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -1,20 +1,35 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mobile/bloc/new_board_sreen_bloc.dart';
+import 'package:mobile/repository/boards_repository.dart';
 import 'package:mobile/view/components/common/button_common.dart';
 import 'package:mobile/view/components/common/textfield_common.dart';
+import 'package:mobile/view/components/notification.dart';
 
 class NewBoardScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider<NewBoardScreenBloc>(
-      create: (context) => NewBoardScreenBloc(),
+      create: (context) => NewBoardScreenBloc(
+        boardRepo: RepositoryProvider.of<BoardsRepository>(context),
+      ),
       child: _buildScreen(context),
     );
   }
 
   Widget _buildScreen(BuildContext context) {
-    return BlocBuilder<NewBoardScreenBloc, NewBoardScreenBlocState>(
+    return BlocConsumer<NewBoardScreenBloc, NewBoardScreenBlocState>(
+      listener: (context, state) {
+        if (state is BoardCreateSuccessState) {
+          Navigator.pop(context, state.createdBoard);
+        }
+        if (state is BoardCreateErrorState) {
+          PinterestNotification.showError(
+            title: 'Failed to create a new board',
+            subtitle: state.errorMessage,
+          );
+        }
+      },
       builder: (context, state) => Scaffold(
         appBar: _buildAppBar(context, state),
         body: Container(

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mobile/bloc/new_board_sreen_bloc.dart';
-import 'package:mobile/view/mock/mock_screen_common.dart';
+import 'package:mobile/view/components/common/textfield_common.dart';
 
 class NewBoardScreen extends StatelessWidget {
   @override
@@ -49,16 +49,14 @@ class NewBoardScreen extends StatelessWidget {
   }
 
   Widget _buildBoardNameTextField(BuildContext context) {
-    return TextField(
-      decoration: InputDecoration(
-        labelText: 'Board name',
-        hintText: 'Type something...',
-        border: OutlineInputBorder(),
-      ),
-      onChanged: (value) {
-        BlocProvider.of<NewBoardScreenBloc>(context)
-            .add(BoardNameChanged(value: value));
-      },
+    return PinterestTextField(
+      props: PinterestTextFieldProps(
+          label: 'Board name',
+          hintText: 'Add',
+          onChanged: (value) {
+            BlocProvider.of<NewBoardScreenBloc>(context)
+                .add(BoardNameChanged(value: value));
+          }),
     );
   }
 

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -62,6 +62,7 @@ class NewBoardScreen extends StatelessWidget {
           padding: const EdgeInsets.all(8),
           child: PinterestButton.primary(
             text: 'Create',
+            loading: state is BoardCreatingState,
             onPressed: state.boardName.isEmpty
                 ? null
                 : () => _onCreateButtonPressed(context),

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -85,7 +85,6 @@ class NewBoardScreen extends StatelessWidget {
   }
 
   void _onCreateButtonPressed(BuildContext context) {
-    final bloc = BlocProvider.of<NewBoardScreenBloc>(context);
-    bloc.add(CreateBoardRequested());
+    BlocProvider.of<NewBoardScreenBloc>(context).add(CreateBoardRequested());
   }
 }

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mobile/bloc/new_board_sreen_bloc.dart';
+import 'package:mobile/view/components/common/button_common.dart';
 import 'package:mobile/view/components/common/textfield_common.dart';
 
 class NewBoardScreen extends StatelessWidget {
@@ -15,25 +16,7 @@ class NewBoardScreen extends StatelessWidget {
   Widget _buildScreen(BuildContext context) {
     return BlocBuilder<NewBoardScreenBloc, NewBoardScreenBlocState>(
       builder: (context, state) => Scaffold(
-        appBar: AppBar(
-          title: Text(
-            'Create a new board',
-          ),
-          leading: Container(
-            child: IconButton(
-              icon: Icon(Icons.close),
-              onPressed: () => Navigator.of(context).pop(),
-            ),
-          ),
-          actions: <Widget>[
-            RaisedButton(
-              child: Text('Create'),
-              onPressed: state.boardName.isEmpty
-                  ? null
-                  : () => _onCreateButtonPressed(context),
-            )
-          ],
-        ),
+        appBar: _buildAppBar(context, state),
         body: Container(
           padding: EdgeInsets.all(16),
           child: Column(
@@ -45,6 +28,31 @@ class NewBoardScreen extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+
+  AppBar _buildAppBar(BuildContext context, NewBoardScreenBlocState state) {
+    return AppBar(
+      title: const Text(
+        'Create a new board',
+      ),
+      leading: Container(
+        child: IconButton(
+          icon: Icon(Icons.close),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      actions: <Widget>[
+        Container(
+          padding: const EdgeInsets.all(8),
+          child: PinterestButton.primary(
+            text: 'Create',
+            onPressed: state.boardName.isEmpty
+                ? null
+                : () => _onCreateButtonPressed(context),
+          ),
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
Fix #118 

* ボード作成失敗時には、画面内でエラーの旨の通知を出します。現状エラーにも関わらず通常の白い通知の見た目なので、#121 でキャッチアップします

![refine-create-board](https://user-images.githubusercontent.com/7913793/84986717-fd79d280-b179-11ea-87c7-e57f09cf1a39.gif)

