### PR TITLE
Feature/7 implement pin edit screen

### DIFF
--- a/lib/model/pin_model.dart
+++ b/lib/model/pin_model.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
@@ -9,10 +10,11 @@ part 'pin_model.g.dart';
 class NewPin {
   NewPin({
     @required this.title,
-    @required this.image,
+    this.image,
     this.description,
     this.url,
     this.isPrivate,
+    this.imageFile,
   });
 
   final String title;
@@ -20,6 +22,7 @@ class NewPin {
   final String url;
   final bool isPrivate;
   final String image;
+  final File imageFile;
 
   factory NewPin.fromJson(Map<String, dynamic> json) => _$NewPinFromJson(json);
 

--- a/lib/util/validator.dart
+++ b/lib/util/validator.dart
@@ -31,4 +31,9 @@ class Validator {
     // TODO(dh9489): url防ぐとかなんやらかんやら
     return null;
   }
+
+  static String isValidPinUrl(String s) {
+    // TODO(dh9489): url防ぐとかなんやらかんやら
+    return null;
+  }
 }

--- a/lib/util/validator.dart
+++ b/lib/util/validator.dart
@@ -21,4 +21,20 @@ class Validator {
 
     return true;
   }
+
+  static String isValidPinTitle(String s) {
+    if (s.length > 20) {
+      return 'title is too long.';
+    }
+
+    return null;
+  }
+
+  static String isValidPinDescription(String s) {
+    if (s.length > 280) {
+      return 'description is too long.';
+    }
+
+    return null;
+  }
 }

--- a/lib/util/validator.dart
+++ b/lib/util/validator.dart
@@ -23,18 +23,12 @@ class Validator {
   }
 
   static String isValidPinTitle(String s) {
-    if (s.length > 20) {
-      return 'title is too long.';
-    }
-
+    // TODO(dh9489): url防ぐとかなんやらかんやら
     return null;
   }
 
   static String isValidPinDescription(String s) {
-    if (s.length > 280) {
-      return 'description is too long.';
-    }
-
+    // TODO(dh9489): url防ぐとかなんやらかんやら
     return null;
   }
 }

--- a/lib/view/components/common/textfield_common.dart
+++ b/lib/view/components/common/textfield_common.dart
@@ -11,6 +11,8 @@ class PinterestTextFieldProps {
     this.maxLines,
     this.minLines,
     this.keyboardType,
+    this.maxLength = null,
+    this.maxLengthEnforced = false,
   });
 
   final FormFieldValidator<String> validator;
@@ -21,6 +23,8 @@ class PinterestTextFieldProps {
   final ValueChanged<String> onSaved;
   final int maxLines, minLines;
   final TextInputType keyboardType;
+  final int maxLength;
+  final bool maxLengthEnforced;
 }
 
 class PinterestTextField extends StatelessWidget {
@@ -46,6 +50,8 @@ class PinterestTextField extends StatelessWidget {
           maxLines: props.maxLines,
           minLines: props.minLines,
           keyboardType: props.keyboardType,
+          maxLength: props.maxLength,
+          maxLengthEnforced: props.maxLengthEnforced,
           decoration: InputDecoration(
             hintText: props.hintText,
             border: InputBorder.none,

--- a/lib/view/components/common/textfield_common.dart
+++ b/lib/view/components/common/textfield_common.dart
@@ -8,6 +8,9 @@ class PinterestTextFieldProps {
     this.obscure = false,
     this.onChanged,
     this.onSaved,
+    this.maxLines,
+    this.minLines,
+    this.keyboardType,
   });
 
   final FormFieldValidator<String> validator;
@@ -16,6 +19,8 @@ class PinterestTextFieldProps {
   final bool obscure;
   final ValueChanged<String> onChanged;
   final ValueChanged<String> onSaved;
+  final int maxLines, minLines;
+  final TextInputType keyboardType;
 }
 
 class PinterestTextField extends StatelessWidget {
@@ -38,6 +43,9 @@ class PinterestTextField extends StatelessWidget {
           validator: props.validator,
           onChanged: props.onChanged,
           onSaved: props.onSaved,
+          maxLines: props.maxLines,
+          minLines: props.minLines,
+          keyboardType: props.keyboardType,
           decoration: InputDecoration(
             hintText: props.hintText,
             border: InputBorder.none,

--- a/lib/view/pin_edit_screen.dart
+++ b/lib/view/pin_edit_screen.dart
@@ -1,10 +1,11 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:image_picker/image_picker.dart';
+import 'package:mobile/model/models.dart';
 import 'package:mobile/routes.dart';
 import 'package:mobile/util/validator.dart';
 import 'package:mobile/view/components/common/textfield_common.dart';
+import 'package:mobile/view/select_board_screen.dart';
 
 class PinEditScreenArguments {
   PinEditScreenArguments({this.file});
@@ -22,25 +23,44 @@ class PinEditScreen extends StatefulWidget {
 }
 
 class PinFormData {
-  PinFormData();
+  PinFormData({
+    this.image,
+    this.title = '',
+    this.description = '',
+    this.url = '',
+    this.isPrivate = false,
+  });
 
+  String image;
   String title;
   String description;
   String url;
   bool isPrivate;
+
+  NewPin toNewPin([File imageFile]) {
+    return NewPin(
+      image: image,
+      imageFile: imageFile,
+      title: title,
+      description: description,
+      url: url,
+      isPrivate: isPrivate,
+    );
+  }
 }
 
 class _PinEditScreenState extends State<PinEditScreen> {
-  final formdata = PinFormData();
+  final PinFormData _formdata = PinFormData();
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
-          title: Text('Create pin'),
+          title: const Text('Create pin'),
         ),
         body: SingleChildScrollView(
           child: Container(
+            margin: const EdgeInsets.only(bottom: 40),
             child: Column(
               children: [
                 Container(
@@ -50,14 +70,11 @@ class _PinEditScreenState extends State<PinEditScreen> {
                     fit: BoxFit.contain,
                   ),
                 ),
-                Divider(),
-                _formField(formdata),
+                const Divider(),
+                _formField(_formdata),
                 RaisedButton(
-                  child: Text('Next'),
-                  onPressed: () {
-                    Navigator.pushNamed(
-                        context, Routes.createNewPinSelectPhoto);
-                  },
+                  child: const Text('Next'),
+                  onPressed: _onNextPressed,
                 )
               ],
             ),
@@ -67,7 +84,7 @@ class _PinEditScreenState extends State<PinEditScreen> {
 
   Widget _formField(PinFormData formData) {
     return Container(
-      padding: EdgeInsets.symmetric(horizontal: 8),
+      padding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
       child: Column(
         children: [
           PinterestTextField(
@@ -79,7 +96,7 @@ class _PinEditScreenState extends State<PinEditScreen> {
                 maxLengthEnforced: false,
                 onChanged: (value) => {
                       setState(() {
-                        formdata.title = value;
+                        _formdata.title = value;
                       })
                     }),
           ),
@@ -95,44 +112,52 @@ class _PinEditScreenState extends State<PinEditScreen> {
               maxLengthEnforced: false,
               onChanged: (value) => {
                 setState(() {
-                  formdata.description = value;
+                  _formdata.description = value;
                 })
               },
             ),
           ),
+          PinterestTextField(
+            props: PinterestTextFieldProps(
+                label: 'URL',
+                hintText: 'ここにURLを書く',
+                validator: Validator.isValidPinUrl,
+                maxLengthEnforced: false,
+                onChanged: (value) => {
+                      setState(() {
+                        _formdata.title = value;
+                      })
+                    }),
+          ),
           Container(
             height: 50,
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Expanded(
-                  child: const Text('Private'),
-                ),
-                Expanded(
+                const Text('Private'),
+                Container(
                   child: Switch(
-                    value: formdata.isPrivate,
+                    value: _formdata.isPrivate,
                     onChanged: (value) {
-                      formdata.isPrivate = value;
+                      setState(() {
+                        _formdata.isPrivate = value;
+                      });
                     },
                   ),
-                ),
+                )
               ],
             ),
           )
-          //             Row(
-          //   children: <Widget>[
-          //     Text('Private board'),
-          //     Spacer(),
-          //     Switch(
-          //       value: formdata.isPrivate,
-          //       onChanged: (value) {
-          //         formdata.isPrivate = value;
-          //       },
-          //     ),
-          //   ],
-          // ),
         ],
       ),
     );
+  }
+
+  void _onNextPressed() {
+    final newPin = _formdata.toNewPin(widget.args.file);
+    Navigator.pushNamed(context, Routes.createNewPinSelectBoard,
+        arguments: SelectBoardScreenArguments(
+          newPin: newPin,
+        ));
   }
 }

--- a/lib/view/pin_edit_screen.dart
+++ b/lib/view/pin_edit_screen.dart
@@ -24,7 +24,7 @@ class PinEditScreen extends StatefulWidget {
 class PinFormData {
   PinFormData();
 
-  String name;
+  String title;
   String description;
   String url;
   bool isPrivate;
@@ -36,31 +36,33 @@ class _PinEditScreenState extends State<PinEditScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text('Create pin'),
-      ),
-      body: Container(
-        child: Column(
-          children: [
-            Container(
-              height: 300,
-              child: Image.file(
-                widget.args.file,
-                fit: BoxFit.contain,
-              ),
-            ),
-            Divider(),
-            _formField(formdata),
-            RaisedButton(
-              child: Text('Next'),
-              onPressed: () {
-                Navigator.pushNamed(context, Routes.createNewPinSelectPhoto);
-              },
-            )
-          ],
+        appBar: AppBar(
+          title: Text('Create pin'),
         ),
-      ),
-    );
+        body: SingleChildScrollView(
+          child: Container(
+            child: Column(
+              children: [
+                Container(
+                  height: 300,
+                  child: Image.file(
+                    widget.args.file,
+                    fit: BoxFit.contain,
+                  ),
+                ),
+                Divider(),
+                _formField(formdata),
+                RaisedButton(
+                  child: Text('Next'),
+                  onPressed: () {
+                    Navigator.pushNamed(
+                        context, Routes.createNewPinSelectPhoto);
+                  },
+                )
+              ],
+            ),
+          ),
+        ));
   }
 
   Widget _formField(PinFormData formData) {
@@ -70,20 +72,65 @@ class _PinEditScreenState extends State<PinEditScreen> {
         children: [
           PinterestTextField(
             props: PinterestTextFieldProps(
-              label: 'Title',
-              hintText: 'ここにタイトルを書く',
-              validator: Validator.isValidPinTitle,
-            ),
+                label: 'Title',
+                hintText: 'ここにタイトルを書く',
+                validator: Validator.isValidPinTitle,
+                maxLength: 30,
+                maxLengthEnforced: false,
+                onChanged: (value) => {
+                      setState(() {
+                        formdata.title = value;
+                      })
+                    }),
           ),
           PinterestTextField(
-              props: PinterestTextFieldProps(
-            label: 'Description',
-            hintText: 'ここに説明を書く',
-            validator: Validator.isValidPinDescription,
-            keyboardType: TextInputType.multiline,
-            minLines: 1,
-            maxLines: 8,
-          )),
+            props: PinterestTextFieldProps(
+              label: 'Description',
+              hintText: 'ここに説明を書く',
+              validator: Validator.isValidPinDescription,
+              keyboardType: TextInputType.multiline,
+              minLines: 1,
+              maxLines: 8,
+              maxLength: 280,
+              maxLengthEnforced: false,
+              onChanged: (value) => {
+                setState(() {
+                  formdata.description = value;
+                })
+              },
+            ),
+          ),
+          Container(
+            height: 50,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Expanded(
+                  child: const Text('Private'),
+                ),
+                Expanded(
+                  child: Switch(
+                    value: formdata.isPrivate,
+                    onChanged: (value) {
+                      formdata.isPrivate = value;
+                    },
+                  ),
+                ),
+              ],
+            ),
+          )
+          //             Row(
+          //   children: <Widget>[
+          //     Text('Private board'),
+          //     Spacer(),
+          //     Switch(
+          //       value: formdata.isPrivate,
+          //       onChanged: (value) {
+          //         formdata.isPrivate = value;
+          //       },
+          //     ),
+          //   ],
+          // ),
         ],
       ),
     );

--- a/lib/view/pin_edit_screen.dart
+++ b/lib/view/pin_edit_screen.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mobile/routes.dart';
+import 'package:mobile/util/validator.dart';
+import 'package:mobile/view/components/common/textfield_common.dart';
 
 class PinEditScreenArguments {
   PinEditScreenArguments({this.file});
@@ -10,10 +12,26 @@ class PinEditScreenArguments {
   File file;
 }
 
-class PinEditScreen extends StatelessWidget {
+class PinEditScreen extends StatefulWidget {
   const PinEditScreen({this.args});
 
   final PinEditScreenArguments args;
+
+  @override
+  _PinEditScreenState createState() => _PinEditScreenState();
+}
+
+class PinFormData {
+  PinFormData();
+
+  String name;
+  String description;
+  String url;
+  bool isPrivate;
+}
+
+class _PinEditScreenState extends State<PinEditScreen> {
+  final formdata = PinFormData();
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +42,15 @@ class PinEditScreen extends StatelessWidget {
       body: Container(
         child: Column(
           children: [
-            Image.file(args.file),
+            Container(
+              height: 300,
+              child: Image.file(
+                widget.args.file,
+                fit: BoxFit.contain,
+              ),
+            ),
+            Divider(),
+            _formField(formdata),
             RaisedButton(
               child: Text('Next'),
               onPressed: () {
@@ -33,6 +59,32 @@ class PinEditScreen extends StatelessWidget {
             )
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _formField(PinFormData formData) {
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 8),
+      child: Column(
+        children: [
+          PinterestTextField(
+            props: PinterestTextFieldProps(
+              label: 'Title',
+              hintText: 'ここにタイトルを書く',
+              validator: Validator.isValidPinTitle,
+            ),
+          ),
+          PinterestTextField(
+              props: PinterestTextFieldProps(
+            label: 'Description',
+            hintText: 'ここに説明を書く',
+            validator: Validator.isValidPinDescription,
+            keyboardType: TextInputType.multiline,
+            minLines: 1,
+            maxLines: 8,
+          )),
+        ],
       ),
     );
   }

--- a/lib/view/pinterest_application.dart
+++ b/lib/view/pinterest_application.dart
@@ -114,7 +114,8 @@ class PinterestApplication extends StatelessWidget {
               final args = settings.arguments as PinEditScreenArguments;
               return _pageRoute(PinEditScreen(args: args));
             case Routes.createNewPinSelectBoard:
-              return _pageRoute(SelectBoardScreen());
+              final args = settings.arguments as SelectBoardScreenArguments;
+              return _pageRoute(SelectBoardScreen(args: args));
           }
           return null;
         },

--- a/lib/view/select_board_screen.dart
+++ b/lib/view/select_board_screen.dart
@@ -1,7 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:mobile/model/models.dart';
 import 'package:mobile/view/mock/mock_screen_common.dart';
 
+class SelectBoardScreenArguments {
+  SelectBoardScreenArguments({
+    this.newPin,
+  });
+
+  final NewPin newPin;
+}
+
 class SelectBoardScreen extends StatelessWidget {
+  SelectBoardScreen({this.args});
+
+  final SelectBoardScreenArguments args;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(


### PR DESCRIPTION
fix #7 

Done
- Pin情報入力画面の実装
  - PinterestTextFieldに一部プロパティの追加
- 画面遷移の実装
  - 引数用のクラス追加、引き渡しまで完了

![ダウンロード](https://user-images.githubusercontent.com/33589533/84996547-610afc80-b188-11ea-8660-186312726f8b.gif)
