### PR TITLE
login/signupでエラー発生時にアプリ内通知を出すようにした

### DIFF
--- a/lib/view/components/common/textfield_common.dart
+++ b/lib/view/components/common/textfield_common.dart
@@ -8,7 +8,7 @@ class PinterestTextFieldProps {
     this.obscure = false,
     this.onChanged,
     this.onSaved,
-    this.maxLines,
+    this.maxLines = 1,
     this.minLines,
     this.keyboardType,
     this.maxLength = null,

--- a/lib/view/onboarding/auth_screen.dart
+++ b/lib/view/onboarding/auth_screen.dart
@@ -1,11 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:mobile/data/account_repository.dart';
 import 'package:mobile/view/onboarding/auth_bloc.dart';
-import 'package:mobile/view/onboarding/authentication_bloc.dart';
-import 'package:mobile/view/onboarding/login_bloc.dart';
 import 'package:mobile/view/onboarding/login_screen.dart';
-import 'package:mobile/view/onboarding/signup_bloc.dart';
 import 'package:mobile/view/onboarding/signup_screen.dart';
 
 class AuthWidget extends StatelessWidget {
@@ -16,21 +12,8 @@ class AuthWidget extends StatelessWidget {
     );
   }
 
-  final _login = BlocProvider(
-    create: (context) => LoginBloc(
-      accountRepository: context.repository<AccountRepository>(),
-      authenticationBloc: BlocProvider.of<AuthenticationBloc>(context),
-    ),
-    child: LoginWidget(),
-  );
-
-  final _signUp = BlocProvider(
-    create: (context) => SignUpBloc(
-      accountRepository: context.repository<AccountRepository>(),
-      authenticationBloc: BlocProvider.of<AuthenticationBloc>(context),
-    ),
-    child: SignUpWidget(),
-  );
+  final _login = LoginWidget();
+  final _signUp = SignUpWidget();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/view/onboarding/login_bloc.dart
+++ b/lib/view/onboarding/login_bloc.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logger/logger.dart';
 import 'package:mobile/data/account_repository.dart';
 import 'package:mobile/view/onboarding/authentication_bloc.dart';
 
@@ -72,7 +73,8 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
             await accountRepository.authenticate(event.email, event.password);
         print('Token: $token');
         authenticationBloc.add(LoggedIn(token: token));
-      } catch (e) {
+      } on Exception catch (e) {
+        Logger().e(e);
         yield LoginFailure(errorMessage: e.toString());
       }
     }

--- a/lib/view/onboarding/login_screen.dart
+++ b/lib/view/onboarding/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:mobile/data/account_repository.dart';
 import 'package:mobile/util/validator.dart';
 import 'package:mobile/view/components/common/button_common.dart';
 import 'package:mobile/view/components/common/textfield_common.dart';
+import 'package:mobile/view/components/notification.dart';
 import 'package:mobile/view/onboarding/auth_bloc.dart';
 import 'package:mobile/view/onboarding/auth_common_widget.dart';
 import 'package:mobile/view/onboarding/authentication_bloc.dart';
@@ -39,11 +40,23 @@ class LoginWidget extends StatelessWidget {
         accountRepository: RepositoryProvider.of<AccountRepository>(context),
         authenticationBloc: BlocProvider.of<AuthenticationBloc>(context),
       ),
-      child: _buildContent(context),
+      child: BlocConsumer<LoginBloc, LoginState>(
+        listener: _listener,
+        builder: _buildContent,
+      ),
     );
   }
 
-  Widget _buildContent(BuildContext context) {
+  void _listener(BuildContext context, LoginState state) {
+    if (state is LoginFailure) {
+      PinterestNotification.showError(
+        title: 'Failed to login.',
+        subtitle: state.errorMessage,
+      );
+    }
+  }
+
+  Widget _buildContent(BuildContext context, LoginState state) {
     return AuthCommonWidget(
       formKey: _formKey,
       message: 'Welcome back!',
@@ -86,26 +99,24 @@ class LoginWidget extends StatelessWidget {
           // Switch page
         },
       ),
-      action: BlocBuilder<LoginBloc, LoginState>(
-        builder: (context, state) => PinterestButton.primary(
-          loading: state is LoginLoading,
-          text: 'Login',
-          onPressed: () {
-            if (state is LoginLoading) {
-              return;
-            }
-            if (_formKey.currentState.validate()) {
-              _formKey.currentState.save();
-              print(_model);
-              BlocProvider.of<LoginBloc>(context).add(
-                LoginRequested(
-                  email: _model.email,
-                  password: _model.password,
-                ),
-              );
-            }
-          },
-        ),
+      action: PinterestButton.primary(
+        loading: state is LoginLoading,
+        text: 'Login',
+        onPressed: () {
+          if (state is LoginLoading) {
+            return;
+          }
+          if (_formKey.currentState.validate()) {
+            _formKey.currentState.save();
+            print(_model);
+            BlocProvider.of<LoginBloc>(context).add(
+              LoginRequested(
+                email: _model.email,
+                password: _model.password,
+              ),
+            );
+          }
+        },
       ),
     );
   }

--- a/lib/view/onboarding/login_screen.dart
+++ b/lib/view/onboarding/login_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mobile/data/account_repository.dart';
 import 'package:mobile/util/validator.dart';
 import 'package:mobile/view/components/common/button_common.dart';
 import 'package:mobile/view/components/common/textfield_common.dart';
 import 'package:mobile/view/onboarding/auth_bloc.dart';
 import 'package:mobile/view/onboarding/auth_common_widget.dart';
+import 'package:mobile/view/onboarding/authentication_bloc.dart';
 import 'package:mobile/view/onboarding/login_bloc.dart';
 
 class LoginFormModel {
@@ -32,6 +34,16 @@ class LoginWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => LoginBloc(
+        accountRepository: RepositoryProvider.of<AccountRepository>(context),
+        authenticationBloc: BlocProvider.of<AuthenticationBloc>(context),
+      ),
+      child: _buildContent(context),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
     return AuthCommonWidget(
       formKey: _formKey,
       message: 'Welcome back!',

--- a/lib/view/onboarding/signup_bloc.dart
+++ b/lib/view/onboarding/signup_bloc.dart
@@ -1,6 +1,7 @@
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
+import 'package:logger/logger.dart';
 import 'package:mobile/data/account_repository.dart';
 import 'package:mobile/view/onboarding/authentication_bloc.dart';
 import 'package:mobile/view/onboarding/login_bloc.dart';
@@ -54,7 +55,8 @@ class SignUpBloc extends Bloc<SignUpEvent, LoginState> {
         );
         print('Token: $token');
         authenticationBloc.add(LoggedIn(token: token));
-      } catch (e) {
+      } on Exception catch (e) {
+        Logger().e(e);
         yield LoginFailure(errorMessage: e.toString());
       }
     }

--- a/lib/view/onboarding/signup_screen.dart
+++ b/lib/view/onboarding/signup_screen.dart
@@ -4,6 +4,7 @@ import 'package:mobile/data/account_repository.dart';
 import 'package:mobile/util/validator.dart';
 import 'package:mobile/view/components/common/button_common.dart';
 import 'package:mobile/view/components/common/textfield_common.dart';
+import 'package:mobile/view/components/notification.dart';
 import 'package:mobile/view/onboarding/auth_bloc.dart';
 import 'package:mobile/view/onboarding/auth_common_widget.dart';
 import 'package:mobile/view/onboarding/authentication_bloc.dart';
@@ -38,11 +39,23 @@ class SignUpWidget extends StatelessWidget {
         accountRepository: RepositoryProvider.of<AccountRepository>(context),
         authenticationBloc: BlocProvider.of<AuthenticationBloc>(context),
       ),
-      child: _buildContent(context),
+      child: BlocConsumer<SignUpBloc, LoginState>(
+        listener: _listener,
+        builder: _buildContent,
+      ),
     );
   }
 
-  Widget _buildContent(BuildContext context) {
+  void _listener(BuildContext context, LoginState state) {
+    if (state is LoginFailure) {
+      PinterestNotification.showError(
+        title: 'Failed to sign up.',
+        subtitle: state.errorMessage,
+      );
+    }
+  }
+
+  Widget _buildContent(BuildContext context, LoginState state) {
     return AuthCommonWidget(
       formKey: _formKey,
       message: 'Welcome!',

--- a/lib/view/onboarding/signup_screen.dart
+++ b/lib/view/onboarding/signup_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mobile/data/account_repository.dart';
 import 'package:mobile/util/validator.dart';
 import 'package:mobile/view/components/common/button_common.dart';
 import 'package:mobile/view/components/common/textfield_common.dart';
 import 'package:mobile/view/onboarding/auth_bloc.dart';
 import 'package:mobile/view/onboarding/auth_common_widget.dart';
+import 'package:mobile/view/onboarding/authentication_bloc.dart';
 import 'package:mobile/view/onboarding/login_bloc.dart';
 import 'package:mobile/view/onboarding/signup_bloc.dart';
 
@@ -31,6 +33,16 @@ class SignUpWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => SignUpBloc(
+        accountRepository: RepositoryProvider.of<AccountRepository>(context),
+        authenticationBloc: BlocProvider.of<AuthenticationBloc>(context),
+      ),
+      child: _buildContent(context),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
     return AuthCommonWidget(
       formKey: _formKey,
       message: 'Welcome!',


### PR DESCRIPTION
Fix #125 

やったこと

* `BlocConsumer`を使って login/signupでエラーになった時にエラーの通知を出すようにした
* blocproviderでラップする部分をリファクタリング
* maxLinesを1にしないと、textfieldのobscureをtrueにできなかったのでデフォルト値として追加
