### PR TITLE
shared_preferenceをラップするクラスの作成

### DIFF
--- a/lib/data/authentication_preferences.dart
+++ b/lib/data/authentication_preferences.dart
@@ -6,8 +6,8 @@ class AuthenticationPreferences {
     @required this.prefs,
   });
 
-  static const _accessToken = 'token';
-  static const _userID = 'userID';
+  static const _accessToken = 'accessToken';
+  static const _userID = 'userId';
 
   final SharedPreferences prefs;
 

--- a/lib/data/authentication_preferences.dart
+++ b/lib/data/authentication_preferences.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AuthenticationPreferences {
+  const AuthenticationPreferences({
+    @required this.prefs,
+  });
+
+  static const _accessToken = 'token';
+  static const _userID = 'userID';
+
+  final SharedPreferences prefs;
+
+  Future<String> getAccessToken() async {
+    return prefs.getString(_accessToken);
+  }
+
+  Future setAccessToken(String value) async {
+    await prefs.setString(_accessToken, value);
+  }
+
+  Future<int> getUserID() async {
+    return prefs.getInt(_userID);
+  }
+
+  Future setUserID(int value) async {
+    await prefs.setInt(_userID, value);
+  }
+
+  Future clear() async {
+    await prefs.clear();
+  }
+}


### PR DESCRIPTION
Fix #152 


* 既存のSharedPreferenceを直接参照している部分を置き換える作業は、別タスク内でついでにやる形でお願いします
