### PR TITLE
タブ間を遷移する時に画面のリロードが走らないようにした

### DIFF
--- a/lib/view/root_screen.dart
+++ b/lib/view/root_screen.dart
@@ -29,7 +29,10 @@ class _RootScreenState extends State<RootScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: rootScreenDestinations[_currentIndex].body,
+      body: IndexedStack(
+        index: _currentIndex,
+        children: rootScreenDestinations.map((e) => e.body).toList(),
+      ),
       bottomNavigationBar: _buildBottomNavigationBar(context),
     );
   }


### PR DESCRIPTION
Fix #129 

* IndexedStackを使った
* 参考: https://stackoverflow.com/a/55512923/4943277
