### PR TITLE
PinGridViewの読み込み中、例外時の表示作成

### DIFF
--- a/lib/bloc/board_detail_screen_bloc.dart
+++ b/lib/bloc/board_detail_screen_bloc.dart
@@ -86,7 +86,7 @@ class BoardDetailScreenBloc
 
   Stream<BoardDetailScreenState> mapLoadPinsPageToState(
       LoadPinsPage event) async* {
-    if (!(state is Loading)) {
+    if (state is! Loading) {
       yield Loading(page: state.page, pins: state.pins);
       try {
         final _additionalPins = await pinsRepository.getBoardPins(

--- a/lib/bloc/board_detail_screen_bloc.dart
+++ b/lib/bloc/board_detail_screen_bloc.dart
@@ -21,13 +21,15 @@ abstract class BoardDetailScreenState extends Equatable {
   const BoardDetailScreenState({
     @required this.page,
     @required this.pins,
+    this.exception,
   });
 
   final int page;
   final List<Pin> pins;
+  final Exception exception;
 
   @override
-  List<Object> get props => [page, pins];
+  List<Object> get props => [page, pins, exception];
 }
 
 class InitialState extends BoardDetailScreenState {
@@ -49,6 +51,15 @@ class Loading extends BoardDetailScreenState {
     @required int page,
     @required List<Pin> pins,
   }) : super(page: page, pins: pins);
+}
+
+class ErrorState extends BoardDetailScreenState {
+  @override
+  const ErrorState({
+    @required int page,
+    @required List<Pin> pins,
+    @required Exception exception,
+  }) : super(page: page, pins: pins, exception: exception);
 }
 
 //////// Bloc ////////
@@ -75,7 +86,7 @@ class BoardDetailScreenBloc
 
   Stream<BoardDetailScreenState> mapLoadPinsPageToState(
       LoadPinsPage event) async* {
-    if (state is InitialState || state is DefaultState) {
+    if (!(state is Loading)) {
       yield Loading(page: state.page, pins: state.pins);
       try {
         final _additionalPins = await pinsRepository.getBoardPins(
@@ -84,7 +95,7 @@ class BoardDetailScreenBloc
         yield DefaultState(page: state.page + 1, pins: _pins);
       } on Exception catch (e) {
         Logger().e(e);
-        yield DefaultState(page: state.page, pins: state.pins);
+        yield ErrorState(page: state.page, pins: state.pins, exception: e);
       }
     }
     return;

--- a/lib/bloc/home_screen_bloc.dart
+++ b/lib/bloc/home_screen_bloc.dart
@@ -79,7 +79,7 @@ class HomeScreenBloc extends Bloc<HomeScreenEvent, HomeScreenState> {
   }
 
   Stream<HomeScreenState> mapLoadPinsPageToState(LoadPinsPage event) async* {
-    if (state is InitialState || state is DefaultState) {
+    if (!(state is Loading)) {
       yield Loading(page: state.page, pins: state.pins);
       try {
         final _additionalPins =

--- a/lib/view/board_detail_screen.dart
+++ b/lib/view/board_detail_screen.dart
@@ -4,11 +4,9 @@ import 'package:mobile/bloc/board_detail_screen_bloc.dart';
 import 'package:mobile/model/board_model.dart';
 import 'package:mobile/model/pin_model.dart';
 import 'package:mobile/repository/repositories.dart';
-import 'package:mobile/view/mock/mock_screen_common.dart';
+import 'package:mobile/routes.dart';
+import 'package:mobile/view/components/reloadable_pin_grid_view.dart';
 import 'package:mobile/view/pin_detail_screen.dart';
-
-import '../routes.dart';
-import 'components/pin_grid_view.dart';
 
 class BoardDetailScreenArguments {
   BoardDetailScreenArguments({
@@ -53,21 +51,14 @@ class BoardDetailScreen extends StatelessWidget {
     if (state is InitialState) {
       blocProvider.add(LoadPinsPage());
     }
-    final controller = ScrollController();
-    controller.addListener(() {
-      if (controller.position.maxScrollExtent <= controller.position.pixels) {
-        blocProvider.add(LoadPinsPage());
-      }
-    });
 
-    print(state.pins.length);
-
-    return Container(
-      child: PinGridView(
-        pins: state.pins,
-        onTap: _onPinTap,
-        controller: controller,
-      ),
+    return ReloadablePinGridView(
+      isLoading: state is Loading,
+      pins: state.pins,
+      onPinTap: _onPinTap,
+      onScrollOut: () => {blocProvider.add(LoadPinsPage())},
+      isError: state is ErrorState,
+      onReload: () => {blocProvider.add(LoadPinsPage())},
     );
   }
 

--- a/lib/view/components/pin_card.dart
+++ b/lib/view/components/pin_card.dart
@@ -20,7 +20,9 @@ class PinCard extends StatelessWidget {
         onTap: onTap,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: [_pinImage(), const SizedBox(height: 4), _pinTitle()],
+          children: pin.title != null
+              ? [_pinImage(), const SizedBox(height: 4), _pinTitle()]
+              : [_pinImage()],
         ),
       ),
     );
@@ -51,7 +53,7 @@ class PinCard extends StatelessWidget {
 
   Widget _pinTitle() {
     return PinterestTypography.body2(
-      pin.title ?? ' ',
+      pin.title,
       overflow: TextOverflow.ellipsis,
       maxLines: 1,
     );

--- a/lib/view/components/pin_card.dart
+++ b/lib/view/components/pin_card.dart
@@ -20,9 +20,7 @@ class PinCard extends StatelessWidget {
         onTap: onTap,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: pin.title.isEmpty
-              ? [_pinImage()]
-              : [_pinImage(), const SizedBox(height: 4), _pinTitle()],
+          children: [_pinImage(), const SizedBox(height: 4), _pinTitle()],
         ),
       ),
     );
@@ -53,7 +51,7 @@ class PinCard extends StatelessWidget {
 
   Widget _pinTitle() {
     return PinterestTypography.body2(
-      pin.title,
+      pin.title ?? ' ',
       overflow: TextOverflow.ellipsis,
       maxLines: 1,
     );

--- a/lib/view/components/pin_grid_view.dart
+++ b/lib/view/components/pin_grid_view.dart
@@ -10,11 +10,16 @@ class PinGridView extends StatelessWidget {
     this.pins = const [],
     this.onTap,
     this.controller,
+    this.shrinkWrap = false,
+    this.primary = false,
+    this.physics,
   });
 
   final List<Pin> pins;
   final PinGridViewCallback onTap;
   final ScrollController controller;
+  final bool shrinkWrap, primary;
+  final ScrollPhysics physics;
 
   @override
   Widget build(BuildContext context) {
@@ -26,6 +31,9 @@ class PinGridView extends StatelessWidget {
       itemBuilder: _itemBuilder,
       staggeredTileBuilder: _staggeredTileBuilder,
       controller: controller,
+      shrinkWrap: shrinkWrap,
+      primary: primary,
+      physics: physics,
     );
   }
 

--- a/lib/view/components/reloadable_pin_grid_view.dart
+++ b/lib/view/components/reloadable_pin_grid_view.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:mobile/model/pin_model.dart';
+import 'package:mobile/view/components/common/button_common.dart';
+import 'package:mobile/view/components/pin_grid_view.dart';
+
+class ReloadablePinGridView extends StatelessWidget {
+  const ReloadablePinGridView({
+    this.isLoading = false,
+    this.pins = const [],
+    this.onPinTap,
+    this.onScrollOut,
+    this.isError = false,
+    this.onReload,
+  });
+
+  final bool isLoading;
+
+  final List<Pin> pins;
+  final PinGridViewCallback onPinTap;
+  final VoidCallback onScrollOut;
+  final bool isError;
+  final VoidCallback onReload;
+
+  @override
+  Widget build(BuildContext context) {
+    if (pins.isEmpty) {
+      if (isLoading) {
+        return Container(
+          child: const Center(
+            child: CircularProgressIndicator(),
+          ),
+        );
+      }
+
+      if (isError) {
+        return Container(
+          child: Center(
+              child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text('画像の読み込みに失敗しました'),
+              PinterestButton.primary(text: 'Reload', onPressed: onReload)
+            ],
+          )),
+        );
+      }
+
+      return Container(
+        child: Center(
+            child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: const [
+            Text('画像が見つかりませんでした'),
+          ],
+        )),
+      );
+    }
+
+    final controller = ScrollController();
+    controller.addListener(() {
+      if (controller.position.maxScrollExtent <= controller.position.pixels) {
+        print('scroll out');
+        onScrollOut();
+      }
+    });
+
+    Widget tailWidget;
+    if (isLoading) {
+      tailWidget = Container(
+        height: 120,
+        child: const Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    } else if (isError) {
+      tailWidget = Container(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('画像の読み込みに失敗しました'),
+            PinterestButton.primary(text: 'Reload', onPressed: onReload)
+          ],
+        ),
+      );
+    }
+
+    return Container(
+        padding: const EdgeInsets.all(8),
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              PinGridView(
+                pins: pins,
+                onTap: onPinTap,
+                shrinkWrap: true,
+                primary: true,
+                physics: const NeverScrollableScrollPhysics(),
+              ),
+              tailWidget ?? Container()
+            ],
+          ),
+          controller: controller,
+        ));
+  }
+}

--- a/lib/view/components/reloadable_pin_grid_view.dart
+++ b/lib/view/components/reloadable_pin_grid_view.dart
@@ -21,39 +21,49 @@ class ReloadablePinGridView extends StatelessWidget {
   final bool isError;
   final VoidCallback onReload;
 
+  Widget _loadingWidget() {
+    return Container(
+      height: 160,
+      child: const Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+
+  Widget _errorWidget() {
+    return Container(
+      child: Center(
+          child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Text('画像の読み込みに失敗しました'),
+          PinterestButton.primary(text: 'Reload', onPressed: onReload)
+        ],
+      )),
+    );
+  }
+
+  Widget _notFoundWidget() {
+    return Container(
+      child: Center(
+          child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: const [
+          Text('画像が見つかりませんでした'),
+        ],
+      )),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     if (pins.isEmpty) {
       if (isLoading) {
-        return Container(
-          child: const Center(
-            child: CircularProgressIndicator(),
-          ),
-        );
+        return _loadingWidget();
+      } else if (isError) {
+        return _errorWidget();
       }
-
-      if (isError) {
-        return Container(
-          child: Center(
-              child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Text('画像の読み込みに失敗しました'),
-              PinterestButton.primary(text: 'Reload', onPressed: onReload)
-            ],
-          )),
-        );
-      }
-
-      return Container(
-        child: Center(
-            child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: const [
-            Text('画像が見つかりませんでした'),
-          ],
-        )),
-      );
+      return _notFoundWidget();
     }
 
     final controller = ScrollController();
@@ -65,22 +75,9 @@ class ReloadablePinGridView extends StatelessWidget {
 
     Widget tailWidget;
     if (isLoading) {
-      tailWidget = Container(
-        height: 120,
-        child: const Center(
-          child: CircularProgressIndicator(),
-        ),
-      );
+      tailWidget = _loadingWidget();
     } else if (isError) {
-      tailWidget = Container(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Text('画像の読み込みに失敗しました'),
-            PinterestButton.primary(text: 'Reload', onPressed: onReload)
-          ],
-        ),
-      );
+      tailWidget = _errorWidget();
     }
 
     return Container(

--- a/lib/view/components/reloadable_pin_grid_view.dart
+++ b/lib/view/components/reloadable_pin_grid_view.dart
@@ -59,7 +59,6 @@ class ReloadablePinGridView extends StatelessWidget {
     final controller = ScrollController();
     controller.addListener(() {
       if (controller.position.maxScrollExtent <= controller.position.pixels) {
-        print('scroll out');
         onScrollOut();
       }
     });

--- a/lib/view/home_screen.dart
+++ b/lib/view/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:mobile/model/models.dart';
 import 'package:mobile/repository/repositories.dart';
 import 'package:mobile/routes.dart';
 import 'package:mobile/view/components/components.dart';
+import 'package:mobile/view/components/reloadable_pin_grid_view.dart';
 
 import 'pin_detail_screen.dart';
 
@@ -37,28 +38,17 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget _contentBuilder(BuildContext context, HomeScreenState state) {
     final blocProvider = BlocProvider.of<HomeScreenBloc>(context);
 
-    final controller = ScrollController();
-    controller.addListener(() {
-      if (controller.position.maxScrollExtent <= controller.position.pixels) {
-        blocProvider.add(LoadPinsPage());
-      }
-    });
-
-    if (state is ErrorState) {
-      return Container(
-        child: const Center(
-          child: Text('画像の読み込みに失敗しました'),
-        ),
-      );
+    if (state is InitialState) {
+      blocProvider.add(LoadPinsPage());
     }
 
-    return Container(
-      padding: const EdgeInsets.all(8),
-      child: PinGridView(
-        pins: state.pins,
-        onTap: _onPinTap,
-        controller: controller,
-      ),
+    return ReloadablePinGridView(
+      isLoading: state is Loading,
+      pins: state.pins,
+      onPinTap: _onPinTap,
+      onScrollOut: () => {blocProvider.add(LoadPinsPage())},
+      isError: state is ErrorState,
+      onReload: () => {blocProvider.add(LoadPinsPage())},
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -323,7 +323,7 @@ packages:
     source: hosted
     version: "2.2.0"
   http_parser:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http_parser
       url: "https://pub.dartlang.org"


### PR DESCRIPTION
fix #192 

- ReloadablePinGridViewの実装（PinGridView + スクロールイベント、例外時の表示、リロード機能）
- HomeScreenとBoarDetailScreenへの適用
- Pin.titleがnullだった場合にPinCardが例外となるバグの修正