### PR TITLE
ピンとボードのフィールドに関するvalidatorの実装

### DIFF
--- a/lib/util/validator.dart
+++ b/lib/util/validator.dart
@@ -25,19 +25,19 @@ class Validator {
     return true;
   }
 
-  static String isValidPinTitle(String s) {
-    // TODO(dh9489): url防ぐとかなんやらかんやら
-    return null;
+  static bool isValidPinTitle(String s) {
+    return s != null && s.length < 100;
   }
 
-  static String isValidPinDescription(String s) {
-    // TODO(dh9489): url防ぐとかなんやらかんやら
-    return null;
+  static bool isValidPinDescription(String s) {
+    return s != null && s.length <= 1000;
   }
 
-  static String isValidPinUrl(String s) {
-    // TODO(dh9489): url防ぐとかなんやらかんやら
-    return null;
+  static bool isValidPinUrl(String s) {
+    const urlPattern =
+        r'https?://([-A-Z0-9.]+)(/[-A-Z0-9+&@#/%=~_|!:,.;]*)?(\?[A-Z0-9+&@#/%=~_|!:‌​,.;]*)?';
+    final result = RegExp(urlPattern, caseSensitive: false);
+    return result.hasMatch(s);
   }
 
   static Future<bool> isValidImageUrl(String s) async {

--- a/lib/util/validator.dart
+++ b/lib/util/validator.dart
@@ -25,6 +25,10 @@ class Validator {
     return true;
   }
 
+  static bool isValidBoardName(String s) {
+    return s != null && s.length < 100;
+  }
+
   static bool isValidPinTitle(String s) {
     return s != null && s.length < 100;
   }

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mobile/bloc/new_board_sreen_bloc.dart';
 import 'package:mobile/repository/boards_repository.dart';
+import 'package:mobile/util/validator.dart';
 import 'package:mobile/view/components/common/button_common.dart';
 import 'package:mobile/view/components/common/textfield_common.dart';
 import 'package:mobile/view/components/notification.dart';
@@ -77,6 +78,12 @@ class NewBoardScreen extends StatelessWidget {
       props: PinterestTextFieldProps(
           label: 'Board name',
           hintText: 'Add',
+          validator: (value) {
+            if (!Validator.isValidBoardName(value)) {
+              return 'Invalid board name';
+            }
+            return null;
+          },
           onChanged: (value) {
             BlocProvider.of<NewBoardScreenBloc>(context)
                 .add(BoardNameChanged(value: value));

--- a/lib/view/pin_edit_screen.dart
+++ b/lib/view/pin_edit_screen.dart
@@ -91,7 +91,12 @@ class _PinEditScreenState extends State<PinEditScreen> {
             props: PinterestTextFieldProps(
                 label: 'Title',
                 hintText: 'ここにタイトルを書く',
-                validator: Validator.isValidPinTitle,
+                validator: (value) {
+                  if (!Validator.isValidPinTitle(value)) {
+                    return 'Invalid pin title';
+                  }
+                  return null;
+                },
                 maxLength: 30,
                 maxLengthEnforced: false,
                 onChanged: (value) => {
@@ -104,7 +109,12 @@ class _PinEditScreenState extends State<PinEditScreen> {
             props: PinterestTextFieldProps(
               label: 'Description',
               hintText: 'ここに説明を書く',
-              validator: Validator.isValidPinDescription,
+              validator: (value) {
+                if (!Validator.isValidPinDescription(value)) {
+                  return 'Invalid pin description';
+                }
+                return null;
+              },
               keyboardType: TextInputType.multiline,
               minLines: 1,
               maxLines: 8,
@@ -121,7 +131,12 @@ class _PinEditScreenState extends State<PinEditScreen> {
             props: PinterestTextFieldProps(
                 label: 'URL',
                 hintText: 'ここにURLを書く',
-                validator: Validator.isValidPinUrl,
+                validator: (value) {
+                  if (!Validator.isValidPinUrl(value)) {
+                    return 'Invalid url';
+                  }
+                  return null;
+                },
                 maxLengthEnforced: false,
                 onChanged: (value) => {
                       setState(() {


### PR DESCRIPTION
Fix #130 

`validate()`を呼んでいないため実際にはバリデーションが行われていないことに気づきました。
#202 で対応します。

