### PR TITLE
ボードの作成とピン作成時のtextfieldの内容をバリデーションするようにした

### DIFF
--- a/lib/util/validator.dart
+++ b/lib/util/validator.dart
@@ -26,15 +26,15 @@ class Validator {
   }
 
   static bool isValidBoardName(String s) {
-    return s != null && s.length < 100;
+    return s != null && s.length <= 30;
   }
 
   static bool isValidPinTitle(String s) {
-    return s != null && s.length < 100;
+    return s != null && s.length <= 30;
   }
 
   static bool isValidPinDescription(String s) {
-    return s != null && s.length <= 1000;
+    return s != null && s.length <= 280;
   }
 
   static bool isValidPinUrl(String s) {

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -8,6 +8,8 @@ import 'package:mobile/view/components/common/textfield_common.dart';
 import 'package:mobile/view/components/notification.dart';
 
 class NewBoardScreen extends StatelessWidget {
+  final _formKey = GlobalKey<FormState>();
+
   @override
   Widget build(BuildContext context) {
     return BlocProvider<NewBoardScreenBloc>(
@@ -74,20 +76,18 @@ class NewBoardScreen extends StatelessWidget {
   }
 
   Widget _buildBoardNameTextField(BuildContext context) {
-    return PinterestTextField(
-      props: PinterestTextFieldProps(
-          label: 'Board name',
-          hintText: 'Add',
-          validator: (value) {
-            if (!Validator.isValidBoardName(value)) {
-              return 'Invalid board name';
-            }
-            return null;
-          },
-          onChanged: (value) {
-            BlocProvider.of<NewBoardScreenBloc>(context)
-                .add(BoardNameChanged(value: value));
-          }),
+    return Form(
+      key: _formKey,
+      child: PinterestTextField(
+        props: PinterestTextFieldProps(
+            label: 'Board name',
+            hintText: 'Add',
+            validator: _boardNameValidator,
+            onChanged: (value) {
+              BlocProvider.of<NewBoardScreenBloc>(context)
+                  .add(BoardNameChanged(value: value));
+            }),
+      ),
     );
   }
 
@@ -108,6 +108,15 @@ class NewBoardScreen extends StatelessWidget {
   }
 
   void _onCreateButtonPressed(BuildContext context) {
-    BlocProvider.of<NewBoardScreenBloc>(context).add(CreateBoardRequested());
+    if (_formKey.currentState.validate()) {
+      BlocProvider.of<NewBoardScreenBloc>(context).add(CreateBoardRequested());
+    }
+  }
+
+  String _boardNameValidator(String value) {
+    if (!Validator.isValidBoardName(value)) {
+      return 'Invalid board name';
+    }
+    return null;
   }
 }

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -83,6 +83,7 @@ class NewBoardScreen extends StatelessWidget {
             label: 'Board name',
             hintText: 'Add',
             validator: _boardNameValidator,
+            maxLength: 30,
             onChanged: (value) {
               BlocProvider.of<NewBoardScreenBloc>(context)
                   .add(BoardNameChanged(value: value));

--- a/lib/view/pin_edit_screen.dart
+++ b/lib/view/pin_edit_screen.dart
@@ -91,12 +91,7 @@ class _PinEditScreenState extends State<PinEditScreen> {
             props: PinterestTextFieldProps(
                 label: 'Title',
                 hintText: 'ここにタイトルを書く',
-                validator: (value) {
-                  if (!Validator.isValidPinTitle(value)) {
-                    return 'Invalid pin title';
-                  }
-                  return null;
-                },
+                validator: _pinTitleValidator,
                 maxLength: 30,
                 maxLengthEnforced: false,
                 onChanged: (value) => {
@@ -109,12 +104,7 @@ class _PinEditScreenState extends State<PinEditScreen> {
             props: PinterestTextFieldProps(
               label: 'Description',
               hintText: 'ここに説明を書く',
-              validator: (value) {
-                if (!Validator.isValidPinDescription(value)) {
-                  return 'Invalid pin description';
-                }
-                return null;
-              },
+              validator: _pinDescriptionValidator,
               keyboardType: TextInputType.multiline,
               minLines: 1,
               maxLines: 8,
@@ -131,12 +121,7 @@ class _PinEditScreenState extends State<PinEditScreen> {
             props: PinterestTextFieldProps(
                 label: 'URL',
                 hintText: 'ここにURLを書く',
-                validator: (value) {
-                  if (!Validator.isValidPinUrl(value)) {
-                    return 'Invalid url';
-                  }
-                  return null;
-                },
+                validator: _pinUrlValidator,
                 maxLengthEnforced: false,
                 onChanged: (value) => {
                       setState(() {
@@ -166,5 +151,26 @@ class _PinEditScreenState extends State<PinEditScreen> {
         ],
       ),
     );
+  }
+
+  String _pinTitleValidator(String value) {
+    if (!Validator.isValidPinTitle(value)) {
+      return 'Invalid pin title';
+    }
+    return null;
+  }
+
+  String _pinDescriptionValidator(String value) {
+    if (!Validator.isValidPinDescription(value)) {
+      return 'Invalid pin description';
+    }
+    return null;
+  }
+
+  String _pinUrlValidator(String value) {
+    if (!Validator.isValidPinUrl(value)) {
+      return 'Invalid url';
+    }
+    return null;
   }
 }

--- a/lib/view/pin_edit_screen.dart
+++ b/lib/view/pin_edit_screen.dart
@@ -51,6 +51,7 @@ class PinFormData {
 
 class _PinEditScreenState extends State<PinEditScreen> {
   final PinFormData _formdata = PinFormData();
+  final _formKey = GlobalKey<FormState>();
 
   @override
   Widget build(BuildContext context) {
@@ -74,8 +75,12 @@ class _PinEditScreenState extends State<PinEditScreen> {
                 _formField(_formdata),
                 PinterestButton.primary(
                     text: 'Next',
-                    onPressed: () => widget.args
-                        .onNextPressed(context, _formdata.toNewPin())),
+                    onPressed: () {
+                      if (_formKey.currentState.validate()) {
+                        widget.args
+                            .onNextPressed(context, _formdata.toNewPin());
+                      }
+                    }),
               ],
             ),
           ),
@@ -87,47 +92,54 @@ class _PinEditScreenState extends State<PinEditScreen> {
       padding: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
       child: Column(
         children: [
-          PinterestTextField(
-            props: PinterestTextFieldProps(
-                label: 'Title',
-                hintText: 'ここにタイトルを書く',
-                validator: _pinTitleValidator,
-                maxLength: 30,
-                maxLengthEnforced: false,
-                onChanged: (value) => {
+          Form(
+            key: _formKey,
+            child: Column(
+              children: <Widget>[
+                PinterestTextField(
+                  props: PinterestTextFieldProps(
+                      label: 'Title',
+                      hintText: 'ここにタイトルを書く',
+                      validator: _pinTitleValidator,
+                      maxLength: 30,
+                      maxLengthEnforced: false,
+                      onChanged: (value) => {
+                            setState(() {
+                              _formdata.title = value;
+                            })
+                          }),
+                ),
+                PinterestTextField(
+                  props: PinterestTextFieldProps(
+                    label: 'Description',
+                    hintText: 'ここに説明を書く',
+                    validator: _pinDescriptionValidator,
+                    keyboardType: TextInputType.multiline,
+                    minLines: 1,
+                    maxLines: 8,
+                    maxLength: 280,
+                    maxLengthEnforced: false,
+                    onChanged: (value) => {
                       setState(() {
-                        _formdata.title = value;
+                        _formdata.description = value;
                       })
-                    }),
-          ),
-          PinterestTextField(
-            props: PinterestTextFieldProps(
-              label: 'Description',
-              hintText: 'ここに説明を書く',
-              validator: _pinDescriptionValidator,
-              keyboardType: TextInputType.multiline,
-              minLines: 1,
-              maxLines: 8,
-              maxLength: 280,
-              maxLengthEnforced: false,
-              onChanged: (value) => {
-                setState(() {
-                  _formdata.description = value;
-                })
-              },
+                    },
+                  ),
+                ),
+                PinterestTextField(
+                  props: PinterestTextFieldProps(
+                      label: 'URL',
+                      hintText: 'ここにURLを書く',
+                      validator: _pinUrlValidator,
+                      maxLengthEnforced: false,
+                      onChanged: (value) => {
+                            setState(() {
+                              _formdata.url = value;
+                            })
+                          }),
+                )
+              ],
             ),
-          ),
-          PinterestTextField(
-            props: PinterestTextFieldProps(
-                label: 'URL',
-                hintText: 'ここにURLを書く',
-                validator: _pinUrlValidator,
-                maxLengthEnforced: false,
-                onChanged: (value) => {
-                      setState(() {
-                        _formdata.url = value;
-                      })
-                    }),
           ),
           Container(
             height: 50,
@@ -168,7 +180,7 @@ class _PinEditScreenState extends State<PinEditScreen> {
   }
 
   String _pinUrlValidator(String value) {
-    if (!Validator.isValidPinUrl(value)) {
+    if (value != null && value.isNotEmpty && !Validator.isValidPinUrl(value)) {
       return 'Invalid url';
     }
     return null;


### PR DESCRIPTION
Fix #202 

やったこと

* `validate()`を呼んでバリデーションされるようにした
* validatorを関数に切り出してリファクタリング

| 1 | 2 |
| - | - |
| ![image](https://user-images.githubusercontent.com/7913793/85660812-07a74e00-b6f1-11ea-9518-bfd89dbcaf4c.png) | ![image](https://user-images.githubusercontent.com/7913793/85660920-2279c280-b6f1-11ea-9891-00321908fe33.png) |

