### PR TITLE
アカウントスクリーンのボード一覧の再読み込み処理の追加

### DIFF
--- a/lib/bloc/account_screen_bloc.dart
+++ b/lib/bloc/account_screen_bloc.dart
@@ -18,7 +18,9 @@ class LoadInitial extends AccountScreenEvent {
   const LoadInitial();
 }
 
-class Refresh extends AccountScreenEvent {}
+class Refresh extends AccountScreenEvent {
+  const Refresh();
+}
 
 //////// State ////////
 abstract class AccountScreenState extends Equatable {

--- a/lib/bloc/account_screen_bloc.dart
+++ b/lib/bloc/account_screen_bloc.dart
@@ -18,6 +18,8 @@ class LoadInitial extends AccountScreenEvent {
   const LoadInitial();
 }
 
+class Refresh extends AccountScreenEvent {}
+
 //////// State ////////
 abstract class AccountScreenState extends Equatable {
   const AccountScreenState({
@@ -91,6 +93,10 @@ class AccountScreenBloc extends Bloc<AccountScreenEvent, AccountScreenState> {
     if (event is LoadInitial) {
       yield* mapLoadInitialToState(event);
     }
+
+    if (event is Refresh) {
+      yield* mapRefreshToState(event);
+    }
   }
 
   Stream<AccountScreenState> mapLoadInitialToState(LoadInitial event) async* {
@@ -121,6 +127,38 @@ class AccountScreenBloc extends Bloc<AccountScreenEvent, AccountScreenState> {
         );
       }
     }
-    return;
+  }
+
+  Stream<AccountScreenState> mapRefreshToState(Refresh event) async* {
+    yield Loading(
+      user: state.user,
+      boards: state.boards,
+      boardPinMap: state.boardPinMap,
+    );
+    try {
+      final userId = accountRepository.getPersistUserId();
+      final boards = await usersRepository.getUserBoards(userId);
+      yield Loading(
+        user: state.user,
+        boards: boards,
+        boardPinMap: state.boardPinMap,
+      );
+
+      final boardPinMap = <int, List<Pin>>{};
+      for (var i = 0; i < boards.length; i++) {
+        final pins =
+            await boardsRepository.getBoardPins(id: boards[i].id, page: 1);
+        boardPinMap.putIfAbsent(boards[i].id, () => pins);
+      }
+      yield DefaultState(
+          user: state.user, boards: boards, boardPinMap: boardPinMap);
+    } on Exception catch (e) {
+      yield ErrorState(
+        user: state.user,
+        boards: state.boards,
+        boardPinMap: state.boardPinMap,
+        error: e,
+      );
+    }
   }
 }

--- a/lib/view/account_screen.dart
+++ b/lib/view/account_screen.dart
@@ -8,6 +8,7 @@ import 'package:mobile/repository/repositories.dart';
 import 'package:mobile/routes.dart';
 import 'package:mobile/view/board_detail_screen.dart';
 import 'package:mobile/view/components/board_grid_view.dart';
+import 'package:mobile/view/components/notification.dart';
 import 'package:mobile/view/components/reloadable_board_grid_view.dart';
 import 'package:mobile/view/components/user_icon.dart';
 import 'package:mobile/view/onboarding/authentication_bloc.dart';
@@ -94,7 +95,13 @@ class AccountScreen extends StatelessWidget {
                 boardPinMap: state.boardPinMap,
                 onBoardTap: _onBoardTap,
                 isError: state is ErrorState,
-                onReload: () => {blocProvider.add(const LoadInitial())},
+                onReload: () {
+                  BlocProvider.of<AccountScreenBloc>(context)
+                      .add(const LoadInitial());
+                },
+                onRefresh: () async {
+                  PinterestNotification.showNotImplemented();
+                },
               ),
             ),
           ],

--- a/lib/view/account_screen.dart
+++ b/lib/view/account_screen.dart
@@ -100,7 +100,7 @@ class AccountScreen extends StatelessWidget {
                       .add(const LoadInitial());
                 },
                 onRefresh: () async {
-                  PinterestNotification.showNotImplemented();
+                  BlocProvider.of<AccountScreenBloc>(context).add(Refresh());
                 },
               ),
             ),

--- a/lib/view/account_screen.dart
+++ b/lib/view/account_screen.dart
@@ -30,26 +30,40 @@ class AccountScreen extends StatelessWidget {
 
     return BlocBuilder<AuthenticationBloc, AuthenticationState>(
       builder: (context, stateAuth) {
-        return Scaffold(
-          appBar: _buildAppBar(context),
-          body: SafeArea(
-            child: BlocProvider(
-              create: (context) => AccountScreenBloc(
-                accountRepository: accountRepository,
-                usersRepository: usersRepository,
-                boardsRepository: boardsRepository,
-              )..add(const LoadInitial()),
+        return BlocProvider(
+          create: (context) => AccountScreenBloc(
+            accountRepository: accountRepository,
+            usersRepository: usersRepository,
+            boardsRepository: boardsRepository,
+          )..add(const LoadInitial()),
+          child: Scaffold(
+            appBar: _buildAppBar(context),
+            body: SafeArea(
               child: _buildContent(context),
             ),
-          ),
-          floatingActionButton: FloatingActionButton(
-            child: const Icon(Icons.add),
-            onPressed: () {
-              Navigator.of(context).pushNamed(Routes.createNew);
-            },
+            floatingActionButton: _buildFAB(context),
           ),
         );
       },
+    );
+  }
+
+  Widget _buildFAB(BuildContext context) {
+    return BlocBuilder<AccountScreenBloc, AccountScreenState>(
+      builder: (context, state) => FloatingActionButton(
+        child: const Icon(Icons.add),
+        onPressed: () async {
+          final result =
+              await Navigator.of(context).pushNamed(Routes.createNew);
+          if (result is Board) {
+            PinterestNotification.show(
+              title: 'New board created',
+              subtitle: result.name,
+            );
+            BlocProvider.of<AccountScreenBloc>(context).add(Refresh());
+          }
+        },
+      ),
     );
   }
 

--- a/lib/view/account_screen.dart
+++ b/lib/view/account_screen.dart
@@ -37,7 +37,7 @@ class AccountScreen extends StatelessWidget {
                 accountRepository: accountRepository,
                 usersRepository: usersRepository,
                 boardsRepository: boardsRepository,
-              ),
+              )..add(const LoadInitial()),
               child: _buildContent(context),
             ),
           ),
@@ -78,12 +78,6 @@ class AccountScreen extends StatelessWidget {
   Widget _buildContent(BuildContext context) {
     return BlocBuilder<AccountScreenBloc, AccountScreenState>(
       builder: (context, state) {
-        final blocProvider = BlocProvider.of<AccountScreenBloc>(context);
-
-        if (blocProvider.state is InitialState) {
-          blocProvider.add(const LoadInitial());
-        }
-
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [

--- a/lib/view/account_screen.dart
+++ b/lib/view/account_screen.dart
@@ -111,10 +111,11 @@ class AccountScreen extends StatelessWidget {
                 isError: state is ErrorState,
                 onReload: () {
                   BlocProvider.of<AccountScreenBloc>(context)
-                      .add(const LoadInitial());
+                      .add(const Refresh());
                 },
                 onRefresh: () async {
-                  BlocProvider.of<AccountScreenBloc>(context).add(Refresh());
+                  BlocProvider.of<AccountScreenBloc>(context)
+                      .add(const Refresh());
                 },
               ),
             ),

--- a/lib/view/components/board_grid_view.dart
+++ b/lib/view/components/board_grid_view.dart
@@ -46,80 +46,71 @@ class _BoardGridViewState extends State<BoardGridView> {
   final RefreshCallback onRefresh;
 
   Widget _styleLarge(BuildContext context) {
-    return RefreshIndicator(
-      onRefresh: onRefresh,
-      child: StaggeredGridView.countBuilder(
-        padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
-        crossAxisCount: 1,
-        mainAxisSpacing: 4,
-        crossAxisSpacing: 4,
-        shrinkWrap: widget.shrinkWrap,
-        primary: widget.primary,
-        physics: widget.physics,
-        staggeredTileBuilder: (index) {
-          return const StaggeredTile.fit(1);
-        },
-        itemCount: widget.boards.length,
-        itemBuilder: (context, index) {
-          return BoardCardLarge(
-            board: widget.boards[index],
-            pins: widget.boardPinMap[widget.boards[index].id],
-            onTap: () => widget.onTap(context, widget.boards[index]),
-          );
-        },
-      ),
+    return StaggeredGridView.countBuilder(
+      padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
+      crossAxisCount: 1,
+      mainAxisSpacing: 4,
+      crossAxisSpacing: 4,
+      shrinkWrap: widget.shrinkWrap,
+      primary: widget.primary,
+      physics: widget.physics,
+      staggeredTileBuilder: (index) {
+        return const StaggeredTile.fit(1);
+      },
+      itemCount: widget.boards.length,
+      itemBuilder: (context, index) {
+        return BoardCardLarge(
+          board: widget.boards[index],
+          pins: widget.boardPinMap[widget.boards[index].id],
+          onTap: () => widget.onTap(context, widget.boards[index]),
+        );
+      },
     );
   }
 
   Widget _styleCompact(BuildContext context) {
-    return RefreshIndicator(
-      onRefresh: onRefresh,
-      child: StaggeredGridView.countBuilder(
-        padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
-        crossAxisCount: 2,
-        mainAxisSpacing: 4,
-        crossAxisSpacing: 4,
-        shrinkWrap: widget.shrinkWrap,
-        primary: widget.primary,
-        physics: widget.physics,
-        staggeredTileBuilder: (index) {
-          return const StaggeredTile.fit(1);
-        },
-        itemCount: widget.boards.length,
-        itemBuilder: (context, index) {
-          return BoardCardCompact(
-            board: widget.boards[index],
-            pins: widget.boardPinMap[widget.boards[index].id],
-            onTap: () => widget.onTap(context, widget.boards[index]),
-          );
-        },
-      ),
+    return StaggeredGridView.countBuilder(
+      padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
+      crossAxisCount: 2,
+      mainAxisSpacing: 4,
+      crossAxisSpacing: 4,
+      shrinkWrap: widget.shrinkWrap,
+      primary: widget.primary,
+      physics: widget.physics,
+      staggeredTileBuilder: (index) {
+        return const StaggeredTile.fit(1);
+      },
+      itemCount: widget.boards.length,
+      itemBuilder: (context, index) {
+        return BoardCardCompact(
+          board: widget.boards[index],
+          pins: widget.boardPinMap[widget.boards[index].id],
+          onTap: () => widget.onTap(context, widget.boards[index]),
+        );
+      },
     );
   }
 
   Widget _styleSlim(BuildContext context) {
-    return RefreshIndicator(
-      onRefresh: onRefresh,
-      child: StaggeredGridView.countBuilder(
-        padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
-        crossAxisCount: 1,
-        mainAxisSpacing: 4,
-        crossAxisSpacing: 4,
-        shrinkWrap: widget.shrinkWrap,
-        primary: widget.primary,
-        physics: widget.physics,
-        staggeredTileBuilder: (index) {
-          return const StaggeredTile.fit(1);
-        },
-        itemCount: widget.boards.length,
-        itemBuilder: (context, index) {
-          return BoardCardSlim(
-            board: widget.boards[index],
-            pins: widget.boardPinMap[widget.boards[index].id],
-            onTap: () => widget.onTap(context, widget.boards[index]),
-          );
-        },
-      ),
+    return StaggeredGridView.countBuilder(
+      padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
+      crossAxisCount: 1,
+      mainAxisSpacing: 4,
+      crossAxisSpacing: 4,
+      shrinkWrap: widget.shrinkWrap,
+      primary: widget.primary,
+      physics: widget.physics,
+      staggeredTileBuilder: (index) {
+        return const StaggeredTile.fit(1);
+      },
+      itemCount: widget.boards.length,
+      itemBuilder: (context, index) {
+        return BoardCardSlim(
+          board: widget.boards[index],
+          pins: widget.boardPinMap[widget.boards[index].id],
+          onTap: () => widget.onTap(context, widget.boards[index]),
+        );
+      },
     );
   }
 

--- a/lib/view/components/board_grid_view.dart
+++ b/lib/view/components/board_grid_view.dart
@@ -15,6 +15,7 @@ class BoardGridView extends StatefulWidget {
     this.shrinkWrap = false,
     this.primary = false,
     this.physics,
+    this.onRefresh,
   });
 
   final List<Board> boards;
@@ -23,9 +24,12 @@ class BoardGridView extends StatefulWidget {
   final BoardGridViewCallback onTap;
   final bool shrinkWrap, primary;
   final ScrollPhysics physics;
+  final RefreshCallback onRefresh;
 
   @override
-  _BoardGridViewState createState() => _BoardGridViewState();
+  _BoardGridViewState createState() => _BoardGridViewState(
+        onRefresh: onRefresh,
+      );
 }
 
 enum BoardGridViewLayout {
@@ -35,72 +39,87 @@ enum BoardGridViewLayout {
 }
 
 class _BoardGridViewState extends State<BoardGridView> {
-  StaggeredGridView _styleLarge(BuildContext context) {
-    return StaggeredGridView.countBuilder(
-      padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
-      crossAxisCount: 1,
-      mainAxisSpacing: 4,
-      crossAxisSpacing: 4,
-      shrinkWrap: widget.shrinkWrap,
-      primary: widget.primary,
-      physics: widget.physics,
-      staggeredTileBuilder: (index) {
-        return const StaggeredTile.fit(1);
-      },
-      itemCount: widget.boards.length,
-      itemBuilder: (context, index) {
-        return BoardCardLarge(
-          board: widget.boards[index],
-          pins: widget.boardPinMap[widget.boards[index].id],
-          onTap: () => widget.onTap(context, widget.boards[index]),
-        );
-      },
+  _BoardGridViewState({
+    this.onRefresh,
+  });
+
+  final RefreshCallback onRefresh;
+
+  Widget _styleLarge(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      child: StaggeredGridView.countBuilder(
+        padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
+        crossAxisCount: 1,
+        mainAxisSpacing: 4,
+        crossAxisSpacing: 4,
+        shrinkWrap: widget.shrinkWrap,
+        primary: widget.primary,
+        physics: widget.physics,
+        staggeredTileBuilder: (index) {
+          return const StaggeredTile.fit(1);
+        },
+        itemCount: widget.boards.length,
+        itemBuilder: (context, index) {
+          return BoardCardLarge(
+            board: widget.boards[index],
+            pins: widget.boardPinMap[widget.boards[index].id],
+            onTap: () => widget.onTap(context, widget.boards[index]),
+          );
+        },
+      ),
     );
   }
 
-  StaggeredGridView _styleCompact(BuildContext context) {
-    return StaggeredGridView.countBuilder(
-      padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
-      crossAxisCount: 2,
-      mainAxisSpacing: 4,
-      crossAxisSpacing: 4,
-      shrinkWrap: widget.shrinkWrap,
-      primary: widget.primary,
-      physics: widget.physics,
-      staggeredTileBuilder: (index) {
-        return const StaggeredTile.fit(1);
-      },
-      itemCount: widget.boards.length,
-      itemBuilder: (context, index) {
-        return BoardCardCompact(
-          board: widget.boards[index],
-          pins: widget.boardPinMap[widget.boards[index].id],
-          onTap: () => widget.onTap(context, widget.boards[index]),
-        );
-      },
+  Widget _styleCompact(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      child: StaggeredGridView.countBuilder(
+        padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
+        crossAxisCount: 2,
+        mainAxisSpacing: 4,
+        crossAxisSpacing: 4,
+        shrinkWrap: widget.shrinkWrap,
+        primary: widget.primary,
+        physics: widget.physics,
+        staggeredTileBuilder: (index) {
+          return const StaggeredTile.fit(1);
+        },
+        itemCount: widget.boards.length,
+        itemBuilder: (context, index) {
+          return BoardCardCompact(
+            board: widget.boards[index],
+            pins: widget.boardPinMap[widget.boards[index].id],
+            onTap: () => widget.onTap(context, widget.boards[index]),
+          );
+        },
+      ),
     );
   }
 
-  StaggeredGridView _styleSlim(BuildContext context) {
-    return StaggeredGridView.countBuilder(
-      padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
-      crossAxisCount: 1,
-      mainAxisSpacing: 4,
-      crossAxisSpacing: 4,
-      shrinkWrap: widget.shrinkWrap,
-      primary: widget.primary,
-      physics: widget.physics,
-      staggeredTileBuilder: (index) {
-        return const StaggeredTile.fit(1);
-      },
-      itemCount: widget.boards.length,
-      itemBuilder: (context, index) {
-        return BoardCardSlim(
-          board: widget.boards[index],
-          pins: widget.boardPinMap[widget.boards[index].id],
-          onTap: () => widget.onTap(context, widget.boards[index]),
-        );
-      },
+  Widget _styleSlim(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      child: StaggeredGridView.countBuilder(
+        padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
+        crossAxisCount: 1,
+        mainAxisSpacing: 4,
+        crossAxisSpacing: 4,
+        shrinkWrap: widget.shrinkWrap,
+        primary: widget.primary,
+        physics: widget.physics,
+        staggeredTileBuilder: (index) {
+          return const StaggeredTile.fit(1);
+        },
+        itemCount: widget.boards.length,
+        itemBuilder: (context, index) {
+          return BoardCardSlim(
+            board: widget.boards[index],
+            pins: widget.boardPinMap[widget.boards[index].id],
+            onTap: () => widget.onTap(context, widget.boards[index]),
+          );
+        },
+      ),
     );
   }
 

--- a/lib/view/components/board_grid_view.dart
+++ b/lib/view/components/board_grid_view.dart
@@ -15,7 +15,6 @@ class BoardGridView extends StatefulWidget {
     this.shrinkWrap = false,
     this.primary = false,
     this.physics,
-    this.onRefresh,
   });
 
   final List<Board> boards;
@@ -24,12 +23,9 @@ class BoardGridView extends StatefulWidget {
   final BoardGridViewCallback onTap;
   final bool shrinkWrap, primary;
   final ScrollPhysics physics;
-  final RefreshCallback onRefresh;
 
   @override
-  _BoardGridViewState createState() => _BoardGridViewState(
-        onRefresh: onRefresh,
-      );
+  _BoardGridViewState createState() => _BoardGridViewState();
 }
 
 enum BoardGridViewLayout {
@@ -39,13 +35,7 @@ enum BoardGridViewLayout {
 }
 
 class _BoardGridViewState extends State<BoardGridView> {
-  _BoardGridViewState({
-    this.onRefresh,
-  });
-
-  final RefreshCallback onRefresh;
-
-  Widget _styleLarge(BuildContext context) {
+  StaggeredGridView _styleLarge(BuildContext context) {
     return StaggeredGridView.countBuilder(
       padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
       crossAxisCount: 1,
@@ -68,7 +58,7 @@ class _BoardGridViewState extends State<BoardGridView> {
     );
   }
 
-  Widget _styleCompact(BuildContext context) {
+  StaggeredGridView _styleCompact(BuildContext context) {
     return StaggeredGridView.countBuilder(
       padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
       crossAxisCount: 2,
@@ -91,7 +81,7 @@ class _BoardGridViewState extends State<BoardGridView> {
     );
   }
 
-  Widget _styleSlim(BuildContext context) {
+  StaggeredGridView _styleSlim(BuildContext context) {
     return StaggeredGridView.countBuilder(
       padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 2),
       crossAxisCount: 1,

--- a/lib/view/components/reloadable_board_grid_view.dart
+++ b/lib/view/components/reloadable_board_grid_view.dart
@@ -13,6 +13,7 @@ class ReloadableBoardGridView extends StatelessWidget {
     this.onScrollOut,
     this.isError = false,
     this.onReload,
+    this.onRefresh,
   });
 
   final bool isLoading;
@@ -24,6 +25,7 @@ class ReloadableBoardGridView extends StatelessWidget {
   final VoidCallback onScrollOut;
   final bool isError;
   final VoidCallback onReload;
+  final RefreshCallback onRefresh;
 
   Widget _loadingWidget() {
     return Container(
@@ -86,22 +88,25 @@ class ReloadableBoardGridView extends StatelessWidget {
 
     return Container(
         padding: const EdgeInsets.all(8),
-        child: SingleChildScrollView(
-          child: Column(
-            children: [
-              BoardGridView(
-                boards: boards,
-                boardPinMap: boardPinMap,
-                onTap: onBoardTap,
-                shrinkWrap: true,
-                primary: true,
-                physics: const NeverScrollableScrollPhysics(),
-                layout: layout,
-              ),
-              tailWidget ?? Container()
-            ],
+        child: RefreshIndicator(
+          onRefresh: onRefresh,
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                BoardGridView(
+                  boards: boards,
+                  boardPinMap: boardPinMap,
+                  onTap: onBoardTap,
+                  shrinkWrap: true,
+                  primary: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  layout: layout,
+                ),
+                tailWidget ?? Container()
+              ],
+            ),
+            controller: controller,
           ),
-          controller: controller,
         ));
   }
 }

--- a/lib/view/create_new_screen.dart
+++ b/lib/view/create_new_screen.dart
@@ -26,14 +26,8 @@ class CreateNewScreen extends StatelessWidget {
                 text: 'Board',
                 onPressed: () async {
                   final result = await Navigator.of(context)
-                      .pushReplacementNamed(Routes.createNewBoard);
-
-                  if (result is Board) {
-                    PinterestNotification.show(
-                      title: 'New board created',
-                      subtitle: result.name,
-                    );
-                  }
+                      .pushNamed(Routes.createNewBoard);
+                  Navigator.pop(context, result);
                 },
               ),
               const SizedBox(width: 20),

--- a/lib/view/select_board_screen.dart
+++ b/lib/view/select_board_screen.dart
@@ -5,7 +5,7 @@ import 'package:mobile/model/models.dart';
 import 'package:mobile/repository/repositories.dart';
 import 'package:mobile/view/components/components.dart';
 import 'package:mobile/view/components/reloadable_board_grid_view.dart';
-
+import 'package:mobile/view/components/notification.dart';
 import 'components/board_grid_view.dart';
 
 typedef SelectBoardScreenCallback = void Function(BuildContext, Board);
@@ -74,6 +74,9 @@ class SelectBoardScreen extends StatelessWidget {
                 onBoardTap: args.onBoardPressed,
                 isError: state is ErrorState,
                 onReload: () => {blocProvider.add(const LoadInitial())},
+                onRefresh: () async {
+                  PinterestNotification.showNotImplemented();
+                },
               ),
             ],
           ),

--- a/lib/view/select_board_screen.dart
+++ b/lib/view/select_board_screen.dart
@@ -43,7 +43,7 @@ class SelectBoardScreen extends StatelessWidget {
             accountRepository: accountRepository,
             usersRepository: usersRepository,
             boardsRepository: boardsRepository,
-          ),
+          )..add(const LoadInitial()),
           child: _buildContent(context),
         ),
       ),
@@ -53,33 +53,30 @@ class SelectBoardScreen extends StatelessWidget {
   Widget _buildContent(BuildContext context) {
     return BlocBuilder<SelectBoardScreenBloc, SelectBoardScreenState>(
       builder: (context, state) {
-        final blocProvider = BlocProvider.of<SelectBoardScreenBloc>(context);
-
-        if (blocProvider.state is InitialState) {
-          blocProvider.add(const LoadInitial());
-        }
-
-        return SingleChildScrollView(
-          child: Column(
-            children: [
-              const ActionCardSlim(
-                text: 'Add Board',
-                icon: Icon(Icons.add),
-              ),
-              ReloadableBoardGridView(
+        final bloc = BlocProvider.of<SelectBoardScreenBloc>(context);
+        return Column(
+          children: [
+            const ActionCardSlim(
+              text: 'Add Board',
+              icon: Icon(Icons.add),
+            ),
+            Expanded(
+              child: ReloadableBoardGridView(
                 layout: BoardGridViewLayout.slim,
                 isLoading: state is Loading,
                 boards: state.boards,
                 boardPinMap: state.boardPinMap,
                 onBoardTap: args.onBoardPressed,
                 isError: state is ErrorState,
-                onReload: () => {blocProvider.add(const LoadInitial())},
+                onReload: () {
+                  bloc.add(const Refresh());
+                },
                 onRefresh: () async {
-                  PinterestNotification.showNotImplemented();
+                  bloc.add(const Refresh());
                 },
               ),
-            ],
-          ),
+            ),
+          ],
         );
       },
     );


### PR DESCRIPTION
Fix #216 

やったこと

* account screenのボード一覧を引っ張って更新できるようにした
* ボード作成後にaccount screenのボード一覧を更新
