### PR TITLE
home_screen_blocとboard_detail_screen_blocの共通部分であるpinの取得部分を別blocに切り出した

### DIFF
--- a/lib/bloc/board_detail_screen_bloc.dart
+++ b/lib/bloc/board_detail_screen_bloc.dart
@@ -1,103 +1,19 @@
-import 'dart:async';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:equatable/equatable.dart';
-import 'package:logger/logger.dart';
+import 'package:mobile/bloc/pins_bloc.dart';
 import 'package:mobile/model/models.dart';
 import 'package:mobile/repository/repositories.dart';
 
-//////// Event ////////
-abstract class BoardDetailScreenEvent extends Equatable {
-  const BoardDetailScreenEvent();
-
-  @override
-  List<Object> get props => [];
-}
-
-class LoadPinsPage extends BoardDetailScreenEvent {}
-
-//////// State ////////
-abstract class BoardDetailScreenState extends Equatable {
-  const BoardDetailScreenState({
-    @required this.page,
-    @required this.pins,
-    this.exception,
-  });
-
-  final int page;
-  final List<Pin> pins;
-  final Exception exception;
-
-  @override
-  List<Object> get props => [page, pins, exception];
-}
-
-class InitialState extends BoardDetailScreenState {
-  @override
-  InitialState() : super(page: 0, pins: []);
-}
-
-class DefaultState extends BoardDetailScreenState {
-  @override
-  const DefaultState({
-    @required int page,
-    @required List<Pin> pins,
-  }) : super(page: page, pins: pins);
-}
-
-class Loading extends BoardDetailScreenState {
-  @override
-  const Loading({
-    @required int page,
-    @required List<Pin> pins,
-  }) : super(page: page, pins: pins);
-}
-
-class ErrorState extends BoardDetailScreenState {
-  @override
-  const ErrorState({
-    @required int page,
-    @required List<Pin> pins,
-    @required Exception exception,
-  }) : super(page: page, pins: pins, exception: exception);
-}
-
-//////// Bloc ////////
-class BoardDetailScreenBloc
-    extends Bloc<BoardDetailScreenEvent, BoardDetailScreenState> {
-  BoardDetailScreenBloc({
+class BoardDetailScreenBloc extends PinsBloc {
+  BoardDetailScreenBloc(
     this.pinsRepository,
     this.board,
-  });
+  );
 
   final PinsRepository pinsRepository;
   final Board board;
 
   @override
-  BoardDetailScreenState get initialState => InitialState();
-
-  @override
-  Stream<BoardDetailScreenState> mapEventToState(
-      BoardDetailScreenEvent event) async* {
-    if (event is LoadPinsPage) {
-      yield* mapLoadPinsPageToState(event);
-    }
-  }
-
-  Stream<BoardDetailScreenState> mapLoadPinsPageToState(
-      LoadPinsPage event) async* {
-    if (state is! Loading) {
-      yield Loading(page: state.page, pins: state.pins);
-      try {
-        final _additionalPins = await pinsRepository.getBoardPins(
-            boardId: board.id, page: state.page + 1);
-        final _pins = List<Pin>.from(state.pins)..addAll(_additionalPins);
-        yield DefaultState(page: state.page + 1, pins: _pins);
-      } on Exception catch (e) {
-        Logger().e(e);
-        yield ErrorState(page: state.page, pins: state.pins, exception: e);
-      }
-    }
-    return;
-  }
+  Future<List<Pin>> getPins({int page}) => pinsRepository.getBoardPins(
+        boardId: board.id,
+        page: page,
+      );
 }

--- a/lib/bloc/home_screen_bloc.dart
+++ b/lib/bloc/home_screen_bloc.dart
@@ -1,96 +1,12 @@
-import 'dart:async';
-import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:equatable/equatable.dart';
-import 'package:logger/logger.dart';
-import 'package:mobile/model/models.dart';
-import 'package:mobile/repository/repositories.dart';
+import 'package:mobile/bloc/pins_bloc.dart';
+import 'package:mobile/model/pin_model.dart';
+import 'package:mobile/repository/pins_repository.dart';
 
-//////// Event ////////
-abstract class HomeScreenEvent extends Equatable {
-  const HomeScreenEvent();
+class HomeScreenBloc extends PinsBloc {
+  HomeScreenBloc(this.pinsRepository);
+
+  final PinsRepository pinsRepository;
 
   @override
-  List<Object> get props => [];
-}
-
-class LoadPinsPage extends HomeScreenEvent {}
-
-//////// State ////////
-abstract class HomeScreenState extends Equatable {
-  const HomeScreenState({
-    @required this.page,
-    @required this.pins,
-    this.exception,
-  });
-
-  final int page;
-  final List<Pin> pins;
-  final Exception exception;
-
-  @override
-  List<Object> get props => [page, pins, exception];
-}
-
-class InitialState extends HomeScreenState {
-  @override
-  InitialState() : super(page: 0, pins: []);
-}
-
-class DefaultState extends HomeScreenState {
-  @override
-  const DefaultState({
-    @required int page,
-    @required List<Pin> pins,
-  }) : super(page: page, pins: pins);
-}
-
-class Loading extends HomeScreenState {
-  @override
-  const Loading({
-    @required int page,
-    @required List<Pin> pins,
-  }) : super(page: page, pins: pins);
-}
-
-class ErrorState extends HomeScreenState {
-  @override
-  const ErrorState({
-    int page = 0,
-    List<Pin> pins = const [],
-    @required Exception exception,
-  }) : super(page: page, pins: pins, exception: exception);
-}
-
-//////// Bloc ////////
-class HomeScreenBloc extends Bloc<HomeScreenEvent, HomeScreenState> {
-  HomeScreenBloc(this._pinsRepository);
-
-  final PinsRepository _pinsRepository;
-
-  @override
-  HomeScreenState get initialState => InitialState();
-
-  @override
-  Stream<HomeScreenState> mapEventToState(HomeScreenEvent event) async* {
-    if (event is LoadPinsPage) {
-      yield* mapLoadPinsPageToState(event);
-    }
-  }
-
-  Stream<HomeScreenState> mapLoadPinsPageToState(LoadPinsPage event) async* {
-    if (!(state is Loading)) {
-      yield Loading(page: state.page, pins: state.pins);
-      try {
-        final _additionalPins =
-            await _pinsRepository.getHomePagePins(page: state.page + 1);
-        final _pins = List<Pin>.from(state.pins)..addAll(_additionalPins);
-        yield DefaultState(page: state.page + 1, pins: _pins);
-      } on Exception catch (e) {
-        Logger().e(e);
-        yield ErrorState(page: state.page, pins: state.pins, exception: e);
-      }
-    }
-    return;
-  }
+  Future<List<Pin>> getPins({int page}) => pinsRepository.getHomePagePins();
 }

--- a/lib/bloc/pins_bloc.dart
+++ b/lib/bloc/pins_bloc.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:logger/logger.dart';
+import 'package:mobile/model/models.dart';
+
+//////// Event ////////
+enum PinsBlocEvent {
+  loadNext,
+}
+
+//////// State ////////
+abstract class PinsBlocState extends Equatable {
+  const PinsBlocState({
+    @required this.page,
+    @required this.pins,
+    this.exception,
+  });
+
+  final int page;
+  final List<Pin> pins;
+  final Exception exception;
+
+  @override
+  List<Object> get props => [page, pins, exception];
+}
+
+class InitialState extends PinsBlocState {
+  InitialState() : super(page: 0, pins: []);
+}
+
+class DefaultState extends PinsBlocState {
+  const DefaultState({
+    @required int page,
+    @required List<Pin> pins,
+  }) : super(page: page, pins: pins);
+}
+
+class Loading extends PinsBlocState {
+  const Loading({
+    @required int page,
+    @required List<Pin> pins,
+  }) : super(page: page, pins: pins);
+}
+
+class ErrorState extends PinsBlocState {
+  const ErrorState({
+    int page = 0,
+    List<Pin> pins = const [],
+    @required Exception exception,
+  }) : super(page: page, pins: pins, exception: exception);
+}
+
+//////// Bloc ////////
+abstract class PinsBloc extends Bloc<PinsBlocEvent, PinsBlocState> {
+  Future<List<Pin>> getPins({int page});
+
+  @override
+  PinsBlocState get initialState => InitialState();
+
+  @override
+  Stream<PinsBlocState> mapEventToState(PinsBlocEvent event) async* {
+    switch (event) {
+      case PinsBlocEvent.loadNext:
+        yield* mapLoadNextToState(event);
+        break;
+    }
+  }
+
+  Stream<PinsBlocState> mapLoadNextToState(PinsBlocEvent event) async* {
+    if (state is! Loading) {
+      yield Loading(page: state.page, pins: state.pins);
+      try {
+        final nextPage = state.page + 1;
+        final additionalPins = await getPins(page: nextPage);
+        final pins = List<Pin>.from(state.pins)..addAll(additionalPins);
+        yield DefaultState(page: nextPage, pins: pins);
+      } on Exception catch (e) {
+        Logger().e(e);
+        yield ErrorState(page: state.page, pins: state.pins, exception: e);
+      }
+    }
+  }
+}

--- a/lib/view/board_detail_screen.dart
+++ b/lib/view/board_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mobile/bloc/board_detail_screen_bloc.dart';
+import 'package:mobile/bloc/pins_bloc.dart';
 import 'package:mobile/model/board_model.dart';
 import 'package:mobile/model/pin_model.dart';
 import 'package:mobile/repository/repositories.dart';
@@ -26,8 +27,8 @@ class BoardDetailScreen extends StatelessWidget {
     final pinsRepository = RepositoryProvider.of<PinsRepository>(context);
 
     return BlocProvider(
-      create: (context) => BoardDetailScreenBloc(
-          pinsRepository: pinsRepository, board: args.board),
+      create: (context) => BoardDetailScreenBloc(pinsRepository, args.board)
+        ..add(PinsBlocEvent.loadNext),
       child: _buildContent(context),
     );
   }
@@ -38,27 +39,23 @@ class BoardDetailScreen extends StatelessWidget {
         title: Text(args.board.name),
       ),
       body: SafeArea(
-        child: BlocBuilder<BoardDetailScreenBloc, BoardDetailScreenState>(
+        child: BlocBuilder<BoardDetailScreenBloc, PinsBlocState>(
           builder: _contentBuilder,
         ),
       ),
     );
   }
 
-  Widget _contentBuilder(BuildContext context, BoardDetailScreenState state) {
-    final blocProvider = BlocProvider.of<BoardDetailScreenBloc>(context);
-
-    if (state is InitialState) {
-      blocProvider.add(LoadPinsPage());
-    }
+  Widget _contentBuilder(BuildContext context, PinsBlocState state) {
+    final bloc = BlocProvider.of<BoardDetailScreenBloc>(context);
 
     return ReloadablePinGridView(
       isLoading: state is Loading,
       pins: state.pins,
       onPinTap: _onPinTap,
-      onScrollOut: () => {blocProvider.add(LoadPinsPage())},
+      onScrollOut: () => {bloc.add(PinsBlocEvent.loadNext)},
       isError: state is ErrorState,
-      onReload: () => {blocProvider.add(LoadPinsPage())},
+      onReload: () => {bloc.add(PinsBlocEvent.loadNext)},
     );
   }
 

--- a/lib/view/home_screen.dart
+++ b/lib/view/home_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mobile/bloc/home_screen_bloc.dart';
+import 'package:mobile/bloc/pins_bloc.dart';
 import 'package:mobile/model/models.dart';
 import 'package:mobile/repository/repositories.dart';
 import 'package:mobile/routes.dart';
-import 'package:mobile/view/components/components.dart';
 import 'package:mobile/view/components/reloadable_pin_grid_view.dart';
 
 import 'pin_detail_screen.dart';
@@ -22,33 +22,29 @@ class _HomeScreenState extends State<HomeScreen> {
     final pinsRepository = RepositoryProvider.of<PinsRepository>(context);
 
     return BlocProvider(
-      create: (context) => HomeScreenBloc(pinsRepository)..add(LoadPinsPage()),
+      create: (context) =>
+          HomeScreenBloc(pinsRepository)..add(PinsBlocEvent.loadNext),
       child: _buildContent(context),
     );
   }
 
   Widget _buildContent(BuildContext context) {
     return SafeArea(
-      child: BlocBuilder<HomeScreenBloc, HomeScreenState>(
+      child: BlocBuilder<HomeScreenBloc, PinsBlocState>(
         builder: _contentBuilder,
       ),
     );
   }
 
-  Widget _contentBuilder(BuildContext context, HomeScreenState state) {
-    final blocProvider = BlocProvider.of<HomeScreenBloc>(context);
-
-    if (state is InitialState) {
-      blocProvider.add(LoadPinsPage());
-    }
-
+  Widget _contentBuilder(BuildContext context, PinsBlocState state) {
+    final bloc = BlocProvider.of<HomeScreenBloc>(context);
     return ReloadablePinGridView(
       isLoading: state is Loading,
       pins: state.pins,
       onPinTap: _onPinTap,
-      onScrollOut: () => {blocProvider.add(LoadPinsPage())},
+      onScrollOut: () => {bloc.add(PinsBlocEvent.loadNext)},
       isError: state is ErrorState,
-      onReload: () => {blocProvider.add(LoadPinsPage())},
+      onReload: () => {bloc.add(PinsBlocEvent.loadNext)},
     );
   }
 


### PR DESCRIPTION
Fix #242 

## やったこと

* pinの取得に関する部分を pins_bloc として切り出し
  * pins_bloc には 抽象メソッドとして getPins メソッドを置いた。pinの取得方法のみが両者のblocで異なるため。
* home_screen_blocとboard_detail_screen_blocでpins_blocを継承し、抽象メソッドである getPinsをoverrideして実装した。

## 結果

* 重複コードがなくなり、90行くらいコードが減った
