### PR TITLE
NewBoardScreenを再利用可能に

### DIFF
--- a/lib/bloc/new_board_sreen_bloc.dart
+++ b/lib/bloc/new_board_sreen_bloc.dart
@@ -32,7 +32,12 @@ abstract class NewBoardScreenBlocState extends Equatable {
   List<Object> get props => [];
 }
 
-class DefaultState extends NewBoardScreenBlocState {}
+class DefaultState extends NewBoardScreenBlocState {
+  DefaultState({
+    NewBoard newBoard,
+    Board createdBoard,
+  }) : super(newBoard: newBoard, createdBoard: createdBoard);
+}
 
 class BoardCreatingState extends NewBoardScreenBlocState {
   BoardCreatingState({

--- a/lib/bloc/new_board_sreen_bloc.dart
+++ b/lib/bloc/new_board_sreen_bloc.dart
@@ -11,67 +11,49 @@ abstract class NewBoardScreenBlocEvent extends Equatable {
   List<Object> get props => [];
 }
 
-class BoardNameChanged extends NewBoardScreenBlocEvent {
-  BoardNameChanged({
-    @required this.value,
+class CreateBoardRequest extends NewBoardScreenBlocEvent {
+  CreateBoardRequest({
+    @required this.newBoard,
   });
 
-  final String value;
+  final NewBoard newBoard;
 
   @override
-  List<Object> get props => [value];
+  List<Object> get props => [newBoard];
 }
-
-class IsPrivateChanged extends NewBoardScreenBlocEvent {}
-
-class CreateBoardRequested extends NewBoardScreenBlocEvent {}
 
 abstract class NewBoardScreenBlocState extends Equatable {
-  NewBoardScreenBlocState({
-    this.boardName,
-    this.isPrivate,
-  });
+  NewBoardScreenBlocState({this.newBoard, this.createdBoard});
 
-  final String boardName;
-  final bool isPrivate;
+  NewBoard newBoard;
+  Board createdBoard;
 
   @override
-  List<Object> get props => [
-        boardName,
-        isPrivate,
-      ];
+  List<Object> get props => [];
 }
 
-class DefaultState extends NewBoardScreenBlocState {
-  DefaultState({
-    @required String boardName,
-    @required bool isPrivate,
-  }) : super(boardName: boardName, isPrivate: isPrivate);
-}
+class DefaultState extends NewBoardScreenBlocState {}
 
 class BoardCreatingState extends NewBoardScreenBlocState {
   BoardCreatingState({
-    @required String boardName,
-    @required bool isPrivate,
-  }) : super(boardName: boardName, isPrivate: isPrivate);
+    NewBoard newBoard,
+    Board createdBoard,
+  }) : super(newBoard: newBoard, createdBoard: createdBoard);
 }
 
-class BoardCreateSuccessState extends DefaultState {
+class BoardCreateSuccessState extends NewBoardScreenBlocState {
   BoardCreateSuccessState({
-    @required String boardName,
-    @required bool isPrivate,
-    @required this.createdBoard,
-  }) : super(boardName: boardName, isPrivate: isPrivate);
-
-  final Board createdBoard;
+    NewBoard newBoard,
+    Board createdBoard,
+  }) : super(newBoard: newBoard, createdBoard: createdBoard);
 }
 
-class BoardCreateErrorState extends DefaultState {
+class BoardCreateErrorState extends NewBoardScreenBlocState {
   BoardCreateErrorState({
-    @required String boardName,
-    @required bool isPrivate,
+    NewBoard newBoard,
+    Board createdBoard,
     @required this.errorMessage,
-  }) : super(boardName: boardName, isPrivate: isPrivate);
+  }) : super(newBoard: newBoard, createdBoard: createdBoard);
 
   final String errorMessage;
 }
@@ -85,55 +67,34 @@ class NewBoardScreenBloc
   final BoardsRepository boardRepo;
 
   @override
-  NewBoardScreenBlocState get initialState => DefaultState(
-        boardName: '',
-        isPrivate: false,
-      );
+  NewBoardScreenBlocState get initialState => DefaultState();
 
   @override
   Stream<NewBoardScreenBlocState> mapEventToState(
       NewBoardScreenBlocEvent event) async* {
-    if (event is BoardNameChanged) {
-      yield DefaultState(
-        boardName: event.value,
-        isPrivate: state.isPrivate,
-      );
+    if (event is CreateBoardRequest) {
+      yield* mapToCreateBoardRequestState(event);
     }
+  }
 
-    if (event is IsPrivateChanged) {
-      yield DefaultState(
-        boardName: state.boardName,
-        isPrivate: !state.isPrivate,
+  Stream<NewBoardScreenBlocState> mapToCreateBoardRequestState(
+      CreateBoardRequest event) async* {
+    yield BoardCreatingState(newBoard: event.newBoard);
+
+    Logger().d('board: ${event.newBoard}');
+
+    try {
+      final createdBoard = await boardRepo.createBoard(event.newBoard);
+      yield BoardCreateSuccessState(
+        newBoard: event.newBoard,
+        createdBoard: createdBoard,
       );
-    }
-
-    if (event is CreateBoardRequested) {
-      yield BoardCreatingState(
-        boardName: state.boardName,
-        isPrivate: state.isPrivate,
+    } on Exception catch (e) {
+      Logger().e(e);
+      yield BoardCreateErrorState(
+        newBoard: event.newBoard,
+        errorMessage: e.toString(),
       );
-
-      final newBoard = NewBoard(
-        name: state.boardName,
-        isPrivate: state.isPrivate,
-      );
-
-      Logger().d('board: $newBoard');
-
-      try {
-        final createdBoard = await boardRepo.createBoard(newBoard);
-        yield BoardCreateSuccessState(
-          boardName: state.boardName,
-          isPrivate: state.isPrivate,
-          createdBoard: createdBoard,
-        );
-      } on Exception catch (e) {
-        yield BoardCreateErrorState(
-          boardName: state.boardName,
-          isPrivate: state.isPrivate,
-          errorMessage: e.toString(),
-        );
-      }
     }
   }
 }

--- a/lib/view/account_screen.dart
+++ b/lib/view/account_screen.dart
@@ -56,10 +56,6 @@ class AccountScreen extends StatelessWidget {
           final result =
               await Navigator.of(context).pushNamed(Routes.createNew);
           if (result is Board) {
-            PinterestNotification.show(
-              title: 'New board created',
-              subtitle: result.name,
-            );
             BlocProvider.of<AccountScreenBloc>(context).add(Refresh());
           }
         },

--- a/lib/view/create_new_screen.dart
+++ b/lib/view/create_new_screen.dart
@@ -43,11 +43,6 @@ class CreateNewScreen extends StatelessWidget {
   }
 
   Future _onPinPressed(BuildContext context) async {
-    // final pickedFile = await picker.getImage(source: ImageSource.gallery);
-    // final file = File(pickedFile.path);
-    Navigator.of(context).pushReplacementNamed(
-      Routes.createNewPin,
-      // arguments: PinEditScreenArguments(file: file),
-    );
+    Navigator.of(context).pushReplacementNamed(Routes.createNewPin);
   }
 }

--- a/lib/view/new_board_screen.dart
+++ b/lib/view/new_board_screen.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mobile/bloc/new_board_sreen_bloc.dart';
+import 'package:mobile/model/board_model.dart';
 import 'package:mobile/repository/boards_repository.dart';
-import 'package:mobile/util/validator.dart';
-import 'package:mobile/view/components/common/button_common.dart';
-import 'package:mobile/view/components/common/textfield_common.dart';
 import 'package:mobile/view/components/notification.dart';
+import 'package:mobile/view/pages/board_edit_page.dart';
 
 class NewBoardScreen extends StatelessWidget {
   final _formKey = GlobalKey<FormState>();
@@ -22,106 +21,29 @@ class NewBoardScreen extends StatelessWidget {
 
   Widget _buildScreen(BuildContext context) {
     return BlocConsumer<NewBoardScreenBloc, NewBoardScreenBlocState>(
-      listener: (context, state) {
-        if (state is BoardCreateSuccessState) {
-          Navigator.pop(context, state.createdBoard);
-        }
-        if (state is BoardCreateErrorState) {
-          PinterestNotification.showError(
-            title: 'Failed to create a new board',
-            subtitle: state.errorMessage,
-          );
-        }
-      },
-      builder: (context, state) => Scaffold(
-        appBar: _buildAppBar(context, state),
-        body: Container(
-          child: Column(
-            children: [
-              Container(
-                padding: EdgeInsets.all(16),
-                child: Column(
-                  children: <Widget>[
-                    _buildBoardNameTextField(context),
-                    SizedBox(height: 20),
-                    _buildPrivateBoardSwitch(context),
-                  ],
-                ),
-              ),
-              Container(
-                margin: EdgeInsets.symmetric(vertical: 8),
-                child: PinterestButton.primary(
-                  text: 'Create',
-                  loading: state is BoardCreatingState,
-                  onPressed: state.boardName.isEmpty
-                      ? null
-                      : () => _onCreateButtonPressed(context),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
+        listener: (context, state) {
+          if (state is BoardCreateSuccessState) {
+            PinterestNotification.show(
+              title: 'ボードを作成しました',
+              subtitle: state.createdBoard.name,
+            );
+            Navigator.pop(context, state.createdBoard);
+          }
+          if (state is BoardCreateErrorState) {
+            PinterestNotification.showError(
+              title: 'ボードが作成できませんでした',
+              subtitle: '時間を置いて再度お試しください',
+            );
+          }
+        },
+        builder: (context, state) => BoardEditPage(
+              title: 'Create a new board',
+              onSubmit: _onSubmit,
+            ));
   }
 
-  AppBar _buildAppBar(BuildContext context, NewBoardScreenBlocState state) {
-    return AppBar(
-      title: const Text(
-        'Create a new board',
-      ),
-      leading: Container(
-        child: IconButton(
-          icon: Icon(Icons.close),
-          onPressed: () => Navigator.of(context).pop(),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildBoardNameTextField(BuildContext context) {
-    return Form(
-      key: _formKey,
-      child: PinterestTextField(
-        props: PinterestTextFieldProps(
-            label: 'Board name',
-            hintText: 'Add',
-            validator: _boardNameValidator,
-            maxLength: 30,
-            onChanged: (value) {
-              BlocProvider.of<NewBoardScreenBloc>(context)
-                  .add(BoardNameChanged(value: value));
-            }),
-      ),
-    );
-  }
-
-  Widget _buildPrivateBoardSwitch(BuildContext context) {
-    final bloc = BlocProvider.of<NewBoardScreenBloc>(context);
-    return Row(
-      children: <Widget>[
-        Text('Private board'),
-        Spacer(),
-        Switch(
-          value: bloc.state.isPrivate,
-          onChanged: (value) {
-            bloc.add(IsPrivateChanged());
-          },
-        ),
-      ],
-    );
-  }
-
-  void _onCreateButtonPressed(BuildContext context) {
-    if (_formKey.currentState.validate()) {
-      BlocProvider.of<NewBoardScreenBloc>(context).add(CreateBoardRequested());
-    }
-  }
-
-  String _boardNameValidator(String value) {
-    if (!Validator.isValidBoardName(value)) {
-      return 'Invalid board name';
-    }
-    return null;
+  void _onSubmit(BuildContext context, NewBoard newBoard) {
+    BlocProvider.of<NewBoardScreenBloc>(context)
+        .add(CreateBoardRequest(newBoard: newBoard));
   }
 }

--- a/lib/view/pages/board_edit_page.dart
+++ b/lib/view/pages/board_edit_page.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:mobile/model/models.dart';
+import 'package:mobile/util/validator.dart';
+import 'package:mobile/view/components/common/button_common.dart';
+import 'package:mobile/view/components/common/textfield_common.dart';
+
+typedef BoardEditPageCallback = void Function(
+    BuildContext context, NewBoard newBoard);
+
+class BoardEditPage extends StatefulWidget {
+  const BoardEditPage({
+    this.title = '',
+    this.name,
+    this.isPrivate,
+    this.onSubmit,
+  });
+
+  final String title;
+  final String name;
+  final bool isPrivate;
+  final BoardEditPageCallback onSubmit;
+
+  @override
+  _BoardEditPageState createState() => _BoardEditPageState();
+}
+
+class BoardFormData {
+  BoardFormData({
+    this.name = '',
+    this.isPrivate = false,
+  });
+
+  String name;
+  bool isPrivate;
+
+  NewBoard toNewBoard() {
+    return NewBoard(
+      name: name,
+      isPrivate: isPrivate,
+    );
+  }
+}
+
+class _BoardEditPageState extends State<BoardEditPage> {
+  BoardFormData _formData;
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.name != null) {
+      _formData = BoardFormData(
+        name: widget.name,
+        isPrivate: widget.isPrivate,
+      );
+    } else {
+      _formData = BoardFormData(
+        name: '',
+        isPrivate: false,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: _buildAppBar(context),
+      body: Container(
+        child: Column(
+          children: [
+            Container(
+              padding: EdgeInsets.all(16),
+              child: Column(
+                children: <Widget>[
+                  _buildBoardNameTextField(context),
+                  SizedBox(height: 20),
+                  _buildPrivateBoardSwitch(context),
+                ],
+              ),
+            ),
+            Container(
+              margin: EdgeInsets.symmetric(vertical: 8),
+              child: PinterestButton.primary(
+                text: 'Create',
+                onPressed: _formData.name.isEmpty
+                    ? null
+                    : () => _onCreateButtonPressed(context),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  AppBar _buildAppBar(BuildContext context) {
+    return AppBar(
+      title: Text(widget.title),
+      // leading: Container(
+      //   child: IconButton(
+      //     icon: Icon(Icons.close),
+      //     onPressed: () => Navigator.of(context).pop(),
+      //   ),
+      // ),
+    );
+  }
+
+  Widget _buildBoardNameTextField(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: PinterestTextField(
+        props: PinterestTextFieldProps(
+            label: 'Board name',
+            hintText: 'Add',
+            validator: _boardNameValidator,
+            maxLength: 30,
+            onChanged: (value) {
+              setState(() {
+                _formData.name = value;
+              });
+            }),
+      ),
+    );
+  }
+
+  Widget _buildPrivateBoardSwitch(BuildContext context) {
+    return Row(
+      children: <Widget>[
+        Text('Private board'),
+        Spacer(),
+        Switch(
+          value: _formData.isPrivate,
+          onChanged: (value) {
+            _formData.isPrivate = value;
+          },
+        ),
+      ],
+    );
+  }
+
+  void _onCreateButtonPressed(BuildContext context) {
+    if (_formKey.currentState.validate()) {
+      final newBoard = _formData.toNewBoard();
+      widget.onSubmit(context, newBoard);
+    }
+  }
+
+  String _boardNameValidator(String value) {
+    if (!Validator.isValidBoardName(value)) {
+      return 'Invalid board name';
+    }
+    return null;
+  }
+}

--- a/lib/view/pages/board_edit_page.dart
+++ b/lib/view/pages/board_edit_page.dart
@@ -96,12 +96,6 @@ class _BoardEditPageState extends State<BoardEditPage> {
   AppBar _buildAppBar(BuildContext context) {
     return AppBar(
       title: Text(widget.title),
-      // leading: Container(
-      //   child: IconButton(
-      //     icon: Icon(Icons.close),
-      //     onPressed: () => Navigator.of(context).pop(),
-      //   ),
-      // ),
     );
   }
 

--- a/test/bloc/new_board_screen_bloc_test.dart
+++ b/test/bloc/new_board_screen_bloc_test.dart
@@ -21,49 +21,10 @@ void main() {
     });
 
     test('Initial state is DefaultState', () {
-      final expected = DefaultState(boardName: '', isPrivate: false);
+      final expected = DefaultState();
       expect(bloc.initialState, equals(expected));
       expect(bloc.state, equals(expected));
     });
-
-    blocTest<NewBoardScreenBloc, NewBoardScreenBlocEvent,
-        NewBoardScreenBlocState>(
-      'isPrivate should be updated',
-      build: () async => bloc,
-      act: (bloc) async {
-        bloc..add(IsPrivateChanged())..add(IsPrivateChanged());
-      },
-      expect: <NewBoardScreenBlocState>[
-        DefaultState(boardName: '', isPrivate: true),
-        DefaultState(boardName: '', isPrivate: false),
-      ],
-    );
-
-    blocTest<NewBoardScreenBloc, NewBoardScreenBlocEvent,
-        NewBoardScreenBlocState>(
-      'boardName should be updated',
-      build: () async => bloc,
-      act: (bloc) async {
-        bloc.add(BoardNameChanged(value: 'my board'));
-      },
-      expect: <NewBoardScreenBlocState>[
-        DefaultState(boardName: 'my board', isPrivate: false),
-      ],
-    );
-
-    blocTest<NewBoardScreenBloc, NewBoardScreenBlocEvent,
-        NewBoardScreenBlocState>(
-      'when creating new board failed, should be error state',
-      build: () async => bloc,
-      act: (bloc) async {
-        when(boardRepository.createBoard(any)).thenThrow(NetworkError());
-        bloc.add(CreateBoardRequested());
-      },
-      expect: <dynamic>[
-        isA<BoardCreatingState>(),
-        isA<BoardCreateErrorState>(),
-      ],
-    );
 
     blocTest<NewBoardScreenBloc, NewBoardScreenBlocEvent,
         NewBoardScreenBlocState>(
@@ -72,7 +33,8 @@ void main() {
       act: (bloc) async {
         when(boardRepository.createBoard(any))
             .thenAnswer((_) => Future.value(Board.fromMock()));
-        bloc.add(CreateBoardRequested());
+        bloc.add(CreateBoardRequest(
+            newBoard: NewBoard(name: 'test', isPrivate: false)));
       },
       expect: <dynamic>[
         isA<BoardCreatingState>(),


### PR DESCRIPTION
fix #227 

Viewの部分をBoardEditPageに切り分け、
NewBoardScreenでBlocを呼び、Pageに値を流し込むだけに変更
SubmitButtonにはcallback渡す

これにより、同様の仕組み（ScreenでBloc呼んで、Pageに値流す）で、
ボードの編集、ピン作成フローからボードの作成等が、楽に実装できるはず