### PR TITLE
blocのテストを追加で書いた

### DIFF
--- a/lib/bloc/new_pin_screen_bloc.dart
+++ b/lib/bloc/new_pin_screen_bloc.dart
@@ -71,19 +71,23 @@ class NewPinScreenBloc extends Bloc<NewPinScreenEvent, NewPinScreenState> {
   }
 
   Stream<NewPinScreenState> mapSendRequestToState(SendRequest event) async* {
-    if (state is InitialState) {
+    if (state is! Sending) {
       yield Sending();
       try {
         await pinsRepository.createPin(
             event.newPin, event.imageFile, event.board);
         yield Finished();
 
-        event.onSuccess();
+        if (event.onSuccess != null) {
+          event.onSuccess();
+        }
       } on Exception catch (e) {
         Logger().e(e);
         yield ErrorState();
 
-        event.onError();
+        if (event.onError != null) {
+          event.onError();
+        }
       }
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -212,12 +212,12 @@ packages:
     source: hosted
     version: "1.2.0"
   file:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "5.2.1"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -211,13 +211,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
-  fake_async:
-    dependency: transitive
-    description:
-      name: fake_async
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   file:
     dependency: transitive
     description:
@@ -496,7 +489,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.6.4"
   path_provider:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dev_dependencies:
   json_serializable: ^3.3.0
   flutter_native_splash: ^0.1.9
   flutter_flavorizr: ^1.0.3
+  file: ^5.2.1
 
 flutter:
 

--- a/test/bloc/board_detail_screen_bloc_test.dart
+++ b/test/bloc/board_detail_screen_bloc_test.dart
@@ -1,0 +1,59 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile/api/errors/error.dart';
+import 'package:mobile/bloc/board_detail_screen_bloc.dart';
+import 'package:mobile/bloc/pins_bloc.dart';
+import 'package:mobile/model/models.dart';
+import 'package:mobile/repository/pins_repository.dart';
+import 'package:mockito/mockito.dart';
+
+class MockPinsRepository extends Mock implements PinsRepository {}
+
+void main() {
+  group('board detail screen bloc test', () {
+    MockPinsRepository pinsRepository;
+    BoardDetailScreenBloc bloc;
+
+    setUp(() {
+      pinsRepository = MockPinsRepository();
+      bloc = BoardDetailScreenBloc(pinsRepository, Board.fromMock());
+    });
+
+    test('initial state is InitialState', () {
+      expect(bloc.initialState, isA<InitialState>());
+      expect(bloc.state, isA<InitialState>());
+    });
+
+    blocTest<BoardDetailScreenBloc, PinsBlocEvent, PinsBlocState>(
+      'when fetching board pins succeeded, should be default state',
+      build: () async => bloc,
+      act: (bloc) async {
+        when(pinsRepository.getBoardPins(
+          boardId: Board.fromMock().id,
+          page: anyNamed('page'),
+        )).thenAnswer((_) => Future.value([Pin.fromMock()]));
+        bloc.add(PinsBlocEvent.loadNext);
+      },
+      expect: <dynamic>[
+        isA<Loading>(),
+        equals(DefaultState(page: 1, pins: [Pin.fromMock()])),
+      ],
+    );
+
+    blocTest<BoardDetailScreenBloc, PinsBlocEvent, PinsBlocState>(
+      'when fetching board pins failed, should be error state',
+      build: () async => bloc,
+      act: (bloc) async {
+        when(
+          pinsRepository.getBoardPins(
+              boardId: Board.fromMock().id, page: anyNamed('page')),
+        ).thenThrow(NetworkError());
+        bloc.add(PinsBlocEvent.loadNext);
+      },
+      expect: <dynamic>[
+        isA<Loading>(),
+        isA<ErrorState>(),
+      ],
+    );
+  });
+}

--- a/test/bloc/board_detail_screen_bloc_test.dart
+++ b/test/bloc/board_detail_screen_bloc_test.dart
@@ -1,0 +1,62 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile/api/errors/error.dart';
+import 'package:mobile/bloc/board_detail_screen_bloc.dart';
+import 'package:mobile/model/board_model.dart';
+import 'package:mobile/model/models.dart';
+import 'package:mobile/repository/pins_repository.dart';
+import 'package:mockito/mockito.dart';
+
+class MockPinsRepository extends Mock implements PinsRepository {}
+
+void main() {
+  group('board detail screen bloc test', () {
+    MockPinsRepository pinsRepository;
+    BoardDetailScreenBloc bloc;
+
+    setUp(() {
+      pinsRepository = MockPinsRepository();
+      bloc = BoardDetailScreenBloc(
+        pinsRepository: pinsRepository,
+        board: Board.fromMock(),
+      );
+    });
+
+    test('initial state is InitialState', () {
+      expect(bloc.initialState, isA<InitialState>());
+      expect(bloc.state, isA<InitialState>());
+    });
+
+    blocTest<BoardDetailScreenBloc, BoardDetailScreenEvent,
+        BoardDetailScreenState>(
+      'when fetching board data succeeded, should be default state',
+      build: () async => bloc,
+      act: (bloc) async {
+        when(pinsRepository.getBoardPins(
+                boardId: anyNamed('boardId'), page: anyNamed('page')))
+            .thenAnswer((_) => Future.value([Pin.fromMock()]));
+        bloc.add(LoadPinsPage());
+      },
+      expect: <dynamic>[
+        isA<Loading>(),
+        equals(DefaultState(page: 1, pins: [Pin.fromMock()])),
+      ],
+    );
+
+    blocTest<BoardDetailScreenBloc, BoardDetailScreenEvent,
+        BoardDetailScreenState>(
+      'when fetching board data failed, should be error state',
+      build: () async => bloc,
+      act: (bloc) async {
+        when(pinsRepository.getBoardPins(
+                boardId: anyNamed('boardId'), page: anyNamed('page')))
+            .thenThrow(NetworkError());
+        bloc.add(LoadPinsPage());
+      },
+      expect: <dynamic>[
+        isA<Loading>(),
+        isA<ErrorState>(),
+      ],
+    );
+  });
+}

--- a/test/bloc/home_screen_bloc_test.dart
+++ b/test/bloc/home_screen_bloc_test.dart
@@ -1,8 +1,8 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile/api/errors/error.dart';
-import 'package:mobile/bloc/board_detail_screen_bloc.dart';
-import 'package:mobile/model/board_model.dart';
+import 'package:mobile/bloc/home_screen_bloc.dart';
+import 'package:mobile/bloc/pins_bloc.dart';
 import 'package:mobile/model/models.dart';
 import 'package:mobile/repository/pins_repository.dart';
 import 'package:mockito/mockito.dart';
@@ -10,16 +10,13 @@ import 'package:mockito/mockito.dart';
 class MockPinsRepository extends Mock implements PinsRepository {}
 
 void main() {
-  group('board detail screen bloc test', () {
+  group('home screen bloc test', () {
     MockPinsRepository pinsRepository;
-    BoardDetailScreenBloc bloc;
+    HomeScreenBloc bloc;
 
     setUp(() {
       pinsRepository = MockPinsRepository();
-      bloc = BoardDetailScreenBloc(
-        pinsRepository: pinsRepository,
-        board: Board.fromMock(),
-      );
+      bloc = HomeScreenBloc(pinsRepository);
     });
 
     test('initial state is InitialState', () {
@@ -27,15 +24,13 @@ void main() {
       expect(bloc.state, isA<InitialState>());
     });
 
-    blocTest<BoardDetailScreenBloc, BoardDetailScreenEvent,
-        BoardDetailScreenState>(
-      'when fetching board data succeeded, should be default state',
+    blocTest<HomeScreenBloc, PinsBlocEvent, PinsBlocState>(
+      'when fetching home sceen pins succeeded, should be default state',
       build: () async => bloc,
       act: (bloc) async {
-        when(pinsRepository.getBoardPins(
-                boardId: anyNamed('boardId'), page: anyNamed('page')))
+        when(pinsRepository.getHomePagePins(page: anyNamed('page')))
             .thenAnswer((_) => Future.value([Pin.fromMock()]));
-        bloc.add(LoadPinsPage());
+        bloc.add(PinsBlocEvent.loadNext);
       },
       expect: <dynamic>[
         isA<Loading>(),
@@ -43,15 +38,13 @@ void main() {
       ],
     );
 
-    blocTest<BoardDetailScreenBloc, BoardDetailScreenEvent,
-        BoardDetailScreenState>(
-      'when fetching board data failed, should be error state',
+    blocTest<HomeScreenBloc, PinsBlocEvent, PinsBlocState>(
+      'when fetching home screen pins failed, should be error state',
       build: () async => bloc,
       act: (bloc) async {
-        when(pinsRepository.getBoardPins(
-                boardId: anyNamed('boardId'), page: anyNamed('page')))
+        when(pinsRepository.getHomePagePins(page: anyNamed('page')))
             .thenThrow(NetworkError());
-        bloc.add(LoadPinsPage());
+        bloc.add(PinsBlocEvent.loadNext);
       },
       expect: <dynamic>[
         isA<Loading>(),

--- a/test/bloc/new_pin_screen_bloc_test.dart
+++ b/test/bloc/new_pin_screen_bloc_test.dart
@@ -1,0 +1,77 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile/api/errors/error.dart';
+import 'package:mobile/bloc/new_pin_screen_bloc.dart';
+import 'package:mobile/model/models.dart';
+import 'package:mobile/repository/pins_repository.dart';
+import 'package:mockito/mockito.dart';
+
+class MockPinsRepository extends Mock implements PinsRepository {}
+
+final mockFile = MemoryFileSystem().file('image.dart')..writeAsBytesSync([0]);
+
+void main() {
+  group('new pin screen bloc test', () {
+    MockPinsRepository pinsRepository;
+    NewPinScreenBloc bloc;
+
+    setUp(() {
+      pinsRepository = MockPinsRepository();
+      bloc = NewPinScreenBloc(
+        pinsRepository: pinsRepository,
+      );
+    });
+
+    test('initial state is InitialState', () {
+      expect(bloc.initialState, isA<InitialState>());
+      expect(bloc.state, isA<InitialState>());
+    });
+
+    blocTest<NewPinScreenBloc, NewPinScreenEvent, NewPinScreenState>(
+      'when creating new pin succeeded, should be success state',
+      build: () async => bloc,
+      act: (bloc) async {
+        when(pinsRepository.createPin(any, any, any))
+            .thenAnswer((_) => Future.value());
+        bloc.add(SendRequest(
+          newPin: NewPin.fromMock(),
+          imageFile: mockFile,
+          board: Board.fromMock(),
+        ));
+      },
+      expect: <dynamic>[
+        isA<Sending>(),
+        isA<Finished>(),
+      ],
+    );
+
+    blocTest<NewPinScreenBloc, NewPinScreenEvent, NewPinScreenState>(
+      'when creating new pin failed, should be error state and it is retryable',
+      build: () async => bloc,
+      act: (bloc) async {
+        when(pinsRepository.createPin(null, null, null))
+            .thenThrow(NetworkError());
+        when(pinsRepository.createPin(NewPin.fromMock(), any, Board.fromMock()))
+            .thenAnswer((_) => Future.value());
+        bloc
+          ..add(const SendRequest(
+            newPin: null,
+            imageFile: null,
+            board: null,
+          ))
+          ..add(SendRequest(
+            newPin: NewPin.fromMock(),
+            imageFile: mockFile,
+            board: Board.fromMock(),
+          ));
+      },
+      expect: <dynamic>[
+        isA<Sending>(),
+        isA<ErrorState>(),
+        isA<Sending>(),
+        isA<Finished>(),
+      ],
+    );
+  });
+}


### PR DESCRIPTION
Fix #241 

やったこと

* テストを時間内で書けるところまで書きました
* 共通化されていないaccount_screen_blocとselect_board_screen_blocを共通化して、テストを書くのは時間の都合上今後の課題としました
