### PR TITLE
アカウント画面から呼んだピン作成フロー終了時、ボード一覧を更新

### DIFF
--- a/lib/view/account_screen.dart
+++ b/lib/view/account_screen.dart
@@ -53,11 +53,8 @@ class AccountScreen extends StatelessWidget {
       builder: (context, state) => FloatingActionButton(
         child: const Icon(Icons.add),
         onPressed: () async {
-          final result =
-              await Navigator.of(context).pushNamed(Routes.createNew);
-          if (result is Board) {
-            BlocProvider.of<AccountScreenBloc>(context).add(Refresh());
-          }
+          await Navigator.of(context).pushNamed(Routes.createNew);
+          BlocProvider.of<AccountScreenBloc>(context).add(const Refresh());
         },
       ),
     );

--- a/lib/view/create_new_screen.dart
+++ b/lib/view/create_new_screen.dart
@@ -25,9 +25,8 @@ class CreateNewScreen extends StatelessWidget {
               PinterestButton.primary(
                 text: 'Board',
                 onPressed: () async {
-                  final result = await Navigator.of(context)
-                      .pushNamed(Routes.createNewBoard);
-                  Navigator.pop(context, result);
+                  await Navigator.of(context).pushNamed(Routes.createNewBoard);
+                  Navigator.pop(context);
                 },
               ),
               const SizedBox(width: 20),
@@ -43,6 +42,7 @@ class CreateNewScreen extends StatelessWidget {
   }
 
   Future _onPinPressed(BuildContext context) async {
-    Navigator.of(context).pushReplacementNamed(Routes.createNewPin);
+    await Navigator.of(context).pushNamed(Routes.createNewPin);
+    Navigator.pop(context);
   }
 }


### PR DESCRIPTION
fix #261 

やったこと
- accountscreen内からcreatenewscreenを呼んだ場合、戻り値がなんであろうとリフレッシュを呼ぶこと
- createnewscreenからnewpinscreenに遷移する時、replacedではなくする