### PR TITLE
pin cardの画像読み込みエラー時の表示の改善

### DIFF
--- a/lib/view/components/pin_card.dart
+++ b/lib/view/components/pin_card.dart
@@ -38,23 +38,29 @@ class PinCard extends StatelessWidget {
   Widget _pinImage() {
     return CachedNetworkImage(
       imageUrl: pin.imageUrl,
-      placeholder: (context, url) => Container(
-        height: 200,
-        color: Colors.grey[100],
-        child: Center(
+      placeholder: (context, url) {
+        return _placeholder(
           child: CircularProgressIndicator(
             valueColor: AlwaysStoppedAnimation<Color>(Colors.grey[300]),
           ),
-        ),
-      ),
-      errorWidget: (context, url, dynamic error) {
-        Logger().e(error);
-        return Container(
-          child: const Text(
-            'Sorry, failed to load image.',
-          ),
         );
       },
+      errorWidget: (context, url, dynamic error) {
+        Logger().e(error);
+        return _placeholder(
+            child: const Icon(
+          Icons.error_outline,
+          color: Colors.black,
+        ));
+      },
+    );
+  }
+
+  Widget _placeholder({Widget child}) {
+    return Container(
+      height: 200,
+      color: Colors.grey[100],
+      child: Center(child: child),
     );
   }
 


### PR DESCRIPTION
fix #180 

エラー時にテキストではなくplaceholderを表示するように変更
読み込み中とエラー時でplaceholderを共通化し、childを変更することで表示