### PR TITLE
NewPinScreenにおいてピンの画像のFileをbloc層に流して処理しやすいようにした

### DIFF
--- a/lib/bloc/new_pin_screen_bloc.dart
+++ b/lib/bloc/new_pin_screen_bloc.dart
@@ -54,9 +54,11 @@ abstract class NewPinScreenState extends Equatable {
 
 class InitialState extends NewPinScreenState {}
 
-class ImageConfirmed extends NewPinScreenState {
-  const ImageConfirmed({
-    this.image,
+class ImageUnaccepted extends NewPinScreenState {}
+
+class ImageAccepted extends NewPinScreenState {
+  const ImageAccepted({
+    @required this.image,
   });
 
   final File image;
@@ -94,10 +96,12 @@ class NewPinScreenBloc extends Bloc<NewPinScreenEvent, NewPinScreenState> {
 
   Stream<NewPinScreenState> mapImageSelectedToState(
       ImageSelected event) async* {
-    if (event.image != null) {
+    if (event.image == null) {
+      yield ImageUnaccepted();
+    } else {
       // TODO: ファイル形式、ファイルサイズをチェックする #260
       // TODO: 画像を圧縮する
-      yield ImageConfirmed(image: File(event.image.path));
+      yield ImageAccepted(image: File(event.image.path));
     }
   }
 

--- a/lib/bloc/new_pin_screen_bloc.dart
+++ b/lib/bloc/new_pin_screen_bloc.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:logger/logger.dart';
 import 'package:mobile/model/models.dart';
 import 'package:mobile/model/pin_model.dart';
@@ -14,6 +15,17 @@ abstract class NewPinScreenEvent extends Equatable {
 
   @override
   List<Object> get props => [];
+}
+
+class ImageSelected extends NewPinScreenEvent {
+  const ImageSelected({
+    this.image,
+  });
+
+  final PickedFile image;
+
+  @override
+  List<Object> get props => [image?.path];
 }
 
 class SendRequest extends NewPinScreenEvent {
@@ -46,6 +58,17 @@ abstract class NewPinScreenState extends Equatable {
 
 class InitialState extends NewPinScreenState {}
 
+class ImageConfirmed extends NewPinScreenState {
+  const ImageConfirmed({
+    this.image,
+  });
+
+  final File image;
+
+  @override
+  List<Object> get props => [image.path];
+}
+
 class Sending extends NewPinScreenState {}
 
 class Finished extends NewPinScreenState {}
@@ -65,8 +88,20 @@ class NewPinScreenBloc extends Bloc<NewPinScreenEvent, NewPinScreenState> {
 
   @override
   Stream<NewPinScreenState> mapEventToState(NewPinScreenEvent event) async* {
+    if (event is ImageSelected) {
+      yield* mapImageSelectedToState(event);
+    }
     if (event is SendRequest) {
       yield* mapSendRequestToState(event);
+    }
+  }
+
+  Stream<NewPinScreenState> mapImageSelectedToState(
+      ImageSelected event) async* {
+    if (event.image != null) {
+      // TODO: ファイル形式、ファイルサイズをチェックする #260
+      // TODO: 画像を圧縮する
+      yield ImageConfirmed(image: File(event.image.path));
     }
   }
 

--- a/lib/bloc/new_pin_screen_bloc.dart
+++ b/lib/bloc/new_pin_screen_bloc.dart
@@ -33,15 +33,11 @@ class SendRequest extends NewPinScreenEvent {
     @required this.newPin,
     @required this.imageFile,
     @required this.board,
-    this.onSuccess,
-    this.onError,
   });
 
   final NewPin newPin;
   final File imageFile;
   final Board board;
-  final VoidCallback onSuccess;
-  final VoidCallback onError;
 
   @override
   List<Object> get props => [newPin, imageFile, board];
@@ -112,17 +108,9 @@ class NewPinScreenBloc extends Bloc<NewPinScreenEvent, NewPinScreenState> {
         await pinsRepository.createPin(
             event.newPin, event.imageFile, event.board);
         yield Finished();
-
-        if (event.onSuccess != null) {
-          event.onSuccess();
-        }
       } on Exception catch (e) {
         Logger().e(e);
         yield ErrorState();
-
-        if (event.onError != null) {
-          event.onError();
-        }
       }
     }
   }

--- a/lib/view/new_pin_screen.dart
+++ b/lib/view/new_pin_screen.dart
@@ -40,8 +40,12 @@ class NewPinScreen extends StatelessWidget {
   }
 
   Future _listener(BuildContext context, NewPinScreenState state) async {
-    if (state is ImageConfirmed) {
+    if (state is ImageAccepted) {
       await startSequence(context, state.image);
+    }
+
+    if (state is ImageUnaccepted) {
+      _onImageUnaccepted();
     }
 
     if (state is Finished) {
@@ -127,6 +131,10 @@ class NewPinScreen extends StatelessWidget {
     if (res != null && res as bool) {
       Navigator.of(context).pop();
     }
+  }
+
+  void _onImageUnaccepted() {
+    PinterestNotification.showError(title: '対応していない画像です');
   }
 
   void _onSuccess(BuildContext context) {

--- a/lib/view/new_pin_screen.dart
+++ b/lib/view/new_pin_screen.dart
@@ -43,6 +43,14 @@ class NewPinScreen extends StatelessWidget {
     if (state is ImageConfirmed) {
       await startSequence(context, state.image);
     }
+
+    if (state is Finished) {
+      _onSuccess(context);
+    }
+
+    if (state is ErrorState) {
+      _onError(context);
+    }
   }
 
   Widget _builder(BuildContext context, NewPinScreenState state) {
@@ -104,8 +112,6 @@ class NewPinScreen extends StatelessWidget {
                   newPin: result.newPin,
                   imageFile: result.imageFile,
                   board: result.board,
-                  onSuccess: () => _onSuccess(context),
-                  onError: () => _onError(context),
                 ));
               },
             ),

--- a/lib/view/new_pin_screen.dart
+++ b/lib/view/new_pin_screen.dart
@@ -32,46 +32,50 @@ class NewPinScreen extends StatelessWidget {
 
     return BlocProvider(
       create: (context) => NewPinScreenBloc(pinsRepository: _pinsRepository),
-      child: BlocBuilder<NewPinScreenBloc, NewPinScreenState>(
-        builder: (context, state) {
-          return Scaffold(
-            appBar: AppBar(
-              title: const Text('Create Pin'),
-            ),
-            body: Center(
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  PinterestButton.primary(
-                      text: 'Camera',
-                      onPressed: () => _onCameraPressed(context)),
-                  const SizedBox(width: 24),
-                  PinterestButton.primary(
-                      text: 'Library',
-                      onPressed: () => _onLibraryPressed(context))
-                ],
-              ),
-            ),
-          );
-        },
+      child: BlocConsumer<NewPinScreenBloc, NewPinScreenState>(
+        listener: _listener,
+        builder: _builder,
       ),
     );
   }
 
-  Future _onCameraPressed(BuildContext context) async {
-    final pickedFile = await picker.getImage(source: ImageSource.camera);
-    if (pickedFile == null) {
-      return;
+  Future _listener(BuildContext context, NewPinScreenState state) async {
+    if (state is ImageConfirmed) {
+      await startSequence(context, state.image);
     }
-    await startSequence(context, File(pickedFile.path));
   }
 
-  Future _onLibraryPressed(BuildContext context) async {
-    final pickedFile = await picker.getImage(source: ImageSource.gallery);
-    if (pickedFile == null) {
-      return;
-    }
-    await startSequence(context, File(pickedFile.path));
+  Widget _builder(BuildContext context, NewPinScreenState state) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create Pin'),
+      ),
+      body: Center(
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            PinterestButton.primary(
+                text: 'Camera',
+                onPressed: () {
+                  _onImageSourcePressed(context, ImageSource.camera);
+                }),
+            const SizedBox(width: 24),
+            PinterestButton.primary(
+                text: 'Library',
+                onPressed: () {
+                  _onImageSourcePressed(context, ImageSource.gallery);
+                })
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future _onImageSourcePressed(BuildContext context, ImageSource source) async {
+    final pickedFile = await picker.getImage(source: source);
+    BlocProvider.of<NewPinScreenBloc>(context).add(ImageSelected(
+      image: pickedFile,
+    ));
   }
 
   Future startSequence(BuildContext context, File imageFile) async {

--- a/test/bloc/new_pin_screen_bloc_test.dart
+++ b/test/bloc/new_pin_screen_bloc_test.dart
@@ -1,6 +1,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:mobile/api/errors/error.dart';
 import 'package:mobile/bloc/new_pin_screen_bloc.dart';
 import 'package:mobile/model/models.dart';
@@ -27,6 +28,30 @@ void main() {
       expect(bloc.initialState, isA<InitialState>());
       expect(bloc.state, isA<InitialState>());
     });
+
+    blocTest<NewPinScreenBloc, NewPinScreenEvent, NewPinScreenState>(
+      'when image is not selected, should be unaccepted state',
+      build: () async => bloc,
+      act: (bloc) async {
+        bloc.add(const ImageSelected(image: null));
+      },
+      expect: <dynamic>[
+        ImageUnaccepted(),
+      ],
+    );
+
+    blocTest<NewPinScreenBloc, NewPinScreenEvent, NewPinScreenState>(
+      'when image is selected, should be accepted state',
+      build: () async => bloc,
+      act: (bloc) async {
+        bloc.add(ImageSelected(image: PickedFile('image.png')));
+      },
+      expect: <dynamic>[
+        ImageAccepted(
+          image: MemoryFileSystem().file('image.png')..writeAsBytesSync([0]),
+        ),
+      ],
+    );
 
     blocTest<NewPinScreenBloc, NewPinScreenEvent, NewPinScreenState>(
       'when creating new pin succeeded, should be success state',


### PR DESCRIPTION
Fix #263 

## やったこと

* ImageSelected イベントの追加
* ImageUnaccepted, ImageAccepted ステートの追加
* その他UI層とbloc層の分離

