### PR TITLE
onboarding画面の調整

### DIFF
--- a/lib/view/components/common/button_common.dart
+++ b/lib/view/components/common/button_common.dart
@@ -5,35 +5,37 @@ enum PinterestButtonVariant {
   secondary,
 }
 
+enum PinterestButtonSize {
+  normal,
+  big,
+}
+
 class PinterestButton extends StatelessWidget {
-  PinterestButton.primary({
+  const PinterestButton.primary({
     @required this.text,
     @required this.onPressed,
-    bool this.loading = false,
+    this.loading = false,
+    this.size = PinterestButtonSize.normal,
   }) : variant = PinterestButtonVariant.primary;
 
-  PinterestButton.secondary({
+  const PinterestButton.secondary({
     @required this.text,
     @required this.onPressed,
     bool this.loading = false,
+    this.size = PinterestButtonSize.normal,
   }) : variant = PinterestButtonVariant.secondary;
 
   final String text;
   final VoidCallback onPressed;
   final PinterestButtonVariant variant;
   final bool loading;
+  final PinterestButtonSize size;
 
   @override
   Widget build(BuildContext context) {
     return RaisedButton(
       child: loading
-          ? const SizedBox(
-              width: 20,
-              height: 20,
-              child: CircularProgressIndicator(
-                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-              ),
-            )
+          ? _loadingIndicator()
           : Text(
               text,
               style: TextStyle(
@@ -43,11 +45,24 @@ class PinterestButton extends StatelessWidget {
               ),
             ),
       onPressed: onPressed,
+      padding: size == PinterestButtonSize.big
+          ? const EdgeInsets.symmetric(vertical: 16)
+          : const EdgeInsets.symmetric(vertical: 6),
       color: variant == PinterestButtonVariant.primary
           ? Theme.of(context).buttonColor
           : Colors.grey[300],
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(9999),
+      ),
+    );
+  }
+
+  Widget _loadingIndicator() {
+    return const SizedBox(
+      width: 20,
+      height: 20,
+      child: CircularProgressIndicator(
+        valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
       ),
     );
   }

--- a/lib/view/components/flavor_title_badge.dart
+++ b/lib/view/components/flavor_title_badge.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:mobile/flavors.dart';
+
+class FlavorTitleBadge extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      color: Colors.yellow,
+      child: Text(
+        F.title,
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}

--- a/lib/view/onboarding/auth_common_widget.dart
+++ b/lib/view/onboarding/auth_common_widget.dart
@@ -2,15 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:mobile/view/components/common/textfield_common.dart';
 
 class AuthCommonWidget extends StatelessWidget {
-  AuthCommonWidget({
-    @required this.message,
+  const AuthCommonWidget({
     @required this.textFieldsProps,
     this.calloutProps,
     @required this.formKey,
     @required this.action,
   });
 
-  final String message;
   final List<PinterestTextFieldProps> textFieldsProps;
   final AuthCalloutProps calloutProps;
   final GlobalKey<FormState> formKey;
@@ -18,17 +16,15 @@ class AuthCommonWidget extends StatelessWidget {
 
   Widget build(BuildContext context) {
     return Container(
-      padding: EdgeInsets.all(16),
+      padding: const EdgeInsets.all(16),
       child: Center(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            SizedBox(height: 24),
-            _BigText('Pinterest'),
-            SizedBox(height: 24),
-            _BigText(message),
-            SizedBox(height: 24),
+            const SizedBox(height: 24),
+            _BigText('pinko'),
+            const SizedBox(height: 48),
             Form(
               key: formKey,
               child: _TextFieldList(
@@ -41,7 +37,7 @@ class AuthCommonWidget extends StatelessWidget {
               buttonText: calloutProps.buttonText,
               onButtonPressed: calloutProps.onButtonPressed,
             ),
-            SizedBox(height: 24),
+            const SizedBox(height: 24),
             action,
           ],
         ),
@@ -61,21 +57,21 @@ class _TextFieldList extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListView.separated(
       shrinkWrap: true,
-      physics: NeverScrollableScrollPhysics(),
+      physics: const NeverScrollableScrollPhysics(),
       itemBuilder: (context, index) {
         final props = textFieldProps[index];
         return PinterestTextField(
           props: props,
         );
       },
-      separatorBuilder: (context, index) => SizedBox(height: 24),
+      separatorBuilder: (context, index) => const SizedBox(height: 24),
       itemCount: textFieldProps.length,
     );
   }
 }
 
 class _Callout extends StatelessWidget {
-  _Callout({
+  const _Callout({
     @required this.message,
     @required this.buttonText,
     @required this.onButtonPressed,
@@ -95,7 +91,7 @@ class _Callout extends StatelessWidget {
             textColor: Theme.of(context).buttonColor,
             child: Text(buttonText),
             onPressed: onButtonPressed,
-          )
+          ),
         ],
       ),
     );
@@ -123,7 +119,7 @@ class _BigText extends StatelessWidget {
 }
 
 class AuthCalloutProps {
-  AuthCalloutProps({
+  const AuthCalloutProps({
     @required this.message,
     @required this.buttonText,
     @required this.onButtonPressed,

--- a/lib/view/onboarding/auth_screen.dart
+++ b/lib/view/onboarding/auth_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mobile/flavors.dart';
+import 'package:mobile/view/components/flavor_title_badge.dart';
 import 'package:mobile/view/onboarding/auth_navigation_bloc.dart';
 import 'package:mobile/view/onboarding/login_screen.dart';
 import 'package:mobile/view/onboarding/signup_screen.dart';
@@ -23,8 +24,11 @@ class AuthWidget extends StatelessWidget {
       body: SafeArea(
         child: Container(
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
-              Text(F.title),
+              F.appFlavor != Flavor.PRODUCTION
+                  ? FlavorTitleBadge()
+                  : Container(),
               Expanded(
                 child: BlocBuilder<AuthNavigationBloc, AuthNavigationState>(
                     builder: (_, state) =>

--- a/lib/view/onboarding/login_screen.dart
+++ b/lib/view/onboarding/login_screen.dart
@@ -59,12 +59,12 @@ class LoginWidget extends StatelessWidget {
   Widget _buildContent(BuildContext context, LoginState state) {
     return AuthCommonWidget(
       formKey: _formKey,
-      message: 'Welcome back!',
       textFieldsProps: [
         PinterestTextFieldProps(
           label: 'Email',
           hintText: 'Your Email',
           obscure: false,
+          keyboardType: TextInputType.emailAddress,
           validator: (value) {
             if (!Validator.isValidEmail(value)) {
               return 'Invalid email format.';
@@ -101,6 +101,7 @@ class LoginWidget extends StatelessWidget {
       ),
       action: PinterestButton.primary(
         loading: state is LoginLoading,
+        size: PinterestButtonSize.big,
         text: 'Login',
         onPressed: () {
           if (state is LoginLoading) {

--- a/lib/view/onboarding/signup_screen.dart
+++ b/lib/view/onboarding/signup_screen.dart
@@ -58,7 +58,6 @@ class SignUpWidget extends StatelessWidget {
   Widget _buildContent(BuildContext context, LoginState state) {
     return AuthCommonWidget(
       formKey: _formKey,
-      message: 'Welcome!',
       textFieldsProps: [
         PinterestTextFieldProps(
           label: 'User name',
@@ -78,6 +77,7 @@ class SignUpWidget extends StatelessWidget {
           label: 'Email',
           hintText: 'Your Email',
           obscure: false,
+          keyboardType: TextInputType.emailAddress,
           validator: (value) {
             if (!Validator.isValidEmail(value)) {
               return 'Invalid email format.';
@@ -114,6 +114,7 @@ class SignUpWidget extends StatelessWidget {
       action: BlocBuilder<SignUpBloc, LoginState>(
         builder: (context, state) => PinterestButton.primary(
           loading: state is LoginLoading,
+          size: PinterestButtonSize.big,
           text: 'Sign up',
           onPressed: () {
             if (state is LoginLoading) {

--- a/lib/view/pinterest_application.dart
+++ b/lib/view/pinterest_application.dart
@@ -79,7 +79,7 @@ class PinterestApplication extends StatelessWidget {
   Widget _app() {
     return OverlaySupport(
       child: MaterialApp(
-        title: 'Pinterest',
+        title: 'pinko',
         theme: ThemeData(
           appBarTheme: AppBarTheme(
             color: Colors.grey[200],


### PR DESCRIPTION
Fix #285 

全体的に整えました

* [x] Pinterest の文字列を使っているところを pinko に修正する
* [x] Welcome, Welcome back!を削除する
* [x] 画面上部のbuildを表すバナーをprodの時は表示しないようにする
* [x] メールのkeyboardTypeをemailにする https://api.flutter.dev/flutter/services/TextInputType-class.html
* [x] signin/signup のボタンを大きくする

| 1 | 2 |
| - | - |
| ![simulator_screenshot_530D6931-1D46-46AF-B89D-20D441924331](https://user-images.githubusercontent.com/7913793/86310057-1c876280-bc58-11ea-9263-1c0034b2c644.png) | ![simulator_screenshot_88B24E16-0446-43C1-B3C1-72B484E40410](https://user-images.githubusercontent.com/7913793/86310117-388b0400-bc58-11ea-941d-b2b4a539cc22.png) |

