### PR TITLE
ピン詳細画面の画像を上いっぱいに表示するようにした

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:mobile/flavors.dart';
 
@@ -22,7 +24,9 @@ Future<void> loadDotEnv() async {
 
 Future<ApplicationConfig> readConfig() async {
   await loadDotEnv();
-  final apiEndpoint = DotEnv().env['API_ENDPOINT'];
+  final apiEndpoint = F.appFlavor == Flavor.DEV && Platform.isAndroid
+      ? DotEnv().env['API_ENDPOINT_ANDROID']
+      : DotEnv().env['API_ENDPOINT'];
   if (apiEndpoint == null || apiEndpoint.isEmpty) {
     throw Exception('API_ENDPOINT is missing');
   }

--- a/lib/view/pin_detail_screen.dart
+++ b/lib/view/pin_detail_screen.dart
@@ -16,32 +16,28 @@ import 'package:url_launcher/url_launcher.dart';
 
 class PinDetailScreenArguments {
   const PinDetailScreenArguments({
-    this.pin,
-  }) : assert(pin != null);
+    @required this.pin,
+  });
 
   final Pin pin;
 }
 
 class PinDetailScreen extends StatelessWidget {
-  PinDetailScreen({this.args});
+  const PinDetailScreen({this.args});
 
   final PinDetailScreenArguments args;
 
-  UsersRepository _usersRepository;
-
   @override
   Widget build(BuildContext context) {
-    _usersRepository = RepositoryProvider.of(context);
-
     return BlocProvider(
-        create: (context) => PinDetailScreenBloc(
-              usersRepository: _usersRepository,
-              pin: args.pin,
-            )..add(LoadInitial()),
-        child: BlocConsumer<PinDetailScreenBloc, PinDetailScreenState>(
-          listener: (context, state) {},
-          builder: (context, state) => _contentBuilder(context, state),
-        ));
+      create: (context) => PinDetailScreenBloc(
+        usersRepository: RepositoryProvider.of<UsersRepository>(context),
+        pin: args.pin,
+      )..add(const LoadInitial()),
+      child: BlocBuilder<PinDetailScreenBloc, PinDetailScreenState>(
+        builder: _contentBuilder,
+      ),
+    );
   }
 
   Widget _contentBuilder(BuildContext context, PinDetailScreenState state) {
@@ -61,13 +57,13 @@ class PinDetailScreen extends StatelessWidget {
     final user = state.user;
 
     if (state is InitialState || state is Loading) {
-      return Center(
+      return const Center(
         child: CircularProgressIndicator(),
       );
     }
 
     if (state is ErrorState) {
-      return Center(
+      return const Center(
         child: Text('読み込みに失敗しました'),
       );
     }
@@ -79,26 +75,21 @@ class PinDetailScreen extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             _pinImage(args.pin.imageUrl),
-            // TODO 投稿者情報を入れる
             const SizedBox(height: 32),
-
             _buildPinInfo(
               title: args.pin.title,
               description: args.pin.description,
             ),
             const SizedBox(height: 32),
-
             _buildTags(args.pin.tags),
             const SizedBox(height: 32),
-
             UserCard(
               user: user,
               onTap: (context, user) =>
                   {PinterestNotification.showNotImplemented()},
-              margin: EdgeInsets.symmetric(horizontal: 40),
+              margin: const EdgeInsets.symmetric(horizontal: 40),
             ),
             const SizedBox(height: 32),
-
             _buildActions(context),
           ],
         ),

--- a/lib/view/pin_detail_screen.dart
+++ b/lib/view/pin_detail_screen.dart
@@ -45,19 +45,15 @@ class PinDetailScreen extends StatelessWidget {
   }
 
   Widget _contentBuilder(BuildContext context, PinDetailScreenState state) {
-    final bloc = BlocProvider.of<PinDetailScreenBloc>(context);
-
     return Scaffold(
-      body: SafeArea(
-        child: Stack(children: [
-          _builder(context, state),
-          Positioned(
-            left: 12,
-            top: 16,
-            child: _backButton(context),
-          ),
-        ]),
-      ),
+      body: Stack(children: [
+        _builder(context, state),
+        Positioned(
+          left: 12,
+          top: 16,
+          child: SafeArea(child: _backButton(context)),
+        ),
+      ]),
     );
   }
 


### PR DESCRIPTION
やったこと

* ピン詳細画面の画像を上いっぱいに表示
  * iPhone 11のようにノッチのあるデバイスでははみ出して表示され、Pixelのようにノッチのないデバイスではそのまま表示される
* PinDetailScreenのリファクタリング
* ついでにAndroidでデバッグするための設定を少し追加

| iPhone 11 | Pixel |
| - | - |
| ![image](https://user-images.githubusercontent.com/7913793/86321333-c0cad280-bc73-11ea-81fa-0c0d80fd513d.png) | ![image](https://user-images.githubusercontent.com/7913793/86321232-8cefad00-bc73-11ea-9897-fa952a931eda.png) |
